### PR TITLE
Allow non-string config values

### DIFF
--- a/config/crds/authzed.com_spicedbclusters.yaml
+++ b/config/crds/authzed.com_spicedbclusters.yaml
@@ -36,10 +36,9 @@ spec:
             description: ClusterSpec holds the desired state of the cluster.
             properties:
               config:
-                additionalProperties:
-                  type: string
                 description: Config values to be passed to the cluster
                 type: object
+                x-kubernetes-preserve-unknown-fields: true
               secretName:
                 description: SecretName points to a secret (in the same namespace)
                   that holds secret config for the cluster like passwords, credentials,

--- a/pkg/apis/authzed/v1alpha1/types.go
+++ b/pkg/apis/authzed/v1alpha1/types.go
@@ -1,6 +1,10 @@
 package v1alpha1
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	"encoding/json"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 //go:generate go run sigs.k8s.io/controller-tools/cmd/controller-gen crd object rbac:roleName=spicedb-operator-role paths="../../../apis/..." output:crd:artifacts:config=../../../../config/crds output:rbac:artifacts:config=../../../../config/rbac
 //go:generate go run sigs.k8s.io/controller-tools/cmd/controller-gen crd paths="../../../apis/..." output:crd:artifacts:config=../../../bootstrap/crds
@@ -32,7 +36,10 @@ type SpiceDBCluster struct {
 type ClusterSpec struct {
 	// Config values to be passed to the cluster
 	// +optional
-	Config map[string]string `json:"config,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Type=object
+	Config json.RawMessage `json:"config,omitempty"`
 
 	// SecretName points to a secret (in the same namespace) that holds secret
 	// config for the cluster like passwords, credentials, etc.

--- a/pkg/apis/authzed/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/authzed/v1alpha1/zz_generated.deepcopy.go
@@ -6,6 +6,7 @@
 package v1alpha1
 
 import (
+	"encoding/json"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -15,10 +16,8 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 	*out = *in
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
+		*out = make(json.RawMessage, len(*in))
+		copy(*out, *in)
 	}
 }
 

--- a/pkg/bootstrap/crds/authzed.com_spicedbclusters.yaml
+++ b/pkg/bootstrap/crds/authzed.com_spicedbclusters.yaml
@@ -36,10 +36,9 @@ spec:
             description: ClusterSpec holds the desired state of the cluster.
             properties:
               config:
-                additionalProperties:
-                  type: string
                 description: Config values to be passed to the cluster
                 type: object
+                x-kubernetes-preserve-unknown-fields: true
               secretName:
                 description: SecretName points to a secret (in the same namespace)
                   that holds secret config for the cluster like passwords, credentials,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,15 @@
 package config
 
-import "testing"
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/errors"
+)
 
 func TestToEnvVarName(t *testing.T) {
 	tests := []struct {
@@ -18,6 +27,365 @@ func TestToEnvVarName(t *testing.T) {
 			if got := ToEnvVarName(tt.prefix, tt.key); got != tt.want {
 				t.Errorf("ToEnvVarName() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestNewConfig(t *testing.T) {
+	type args struct {
+		nn        types.NamespacedName
+		uid       types.UID
+		image     string
+		rawConfig json.RawMessage
+		secret    *corev1.Secret
+	}
+	tests := []struct {
+		name         string
+		args         args
+		want         *Config
+		wantWarnings []error
+		wantErrs     []error
+	}{
+		{
+			name: "missing required",
+			args: args{
+				nn:    types.NamespacedName{Namespace: "test", Name: "test"},
+				uid:   types.UID("1"),
+				image: "image",
+				rawConfig: json.RawMessage(`
+					{
+						"test": "field"
+					}
+				`),
+			},
+			wantErrs: []error{
+				fmt.Errorf("datastoreEngine is a required field"),
+				fmt.Errorf("secret must be provided"),
+			},
+			wantWarnings: []error{fmt.Errorf("no TLS configured, consider setting \"tlsSecretName\"")},
+		},
+		{
+			name: "simple",
+			args: args{
+				nn:    types.NamespacedName{Namespace: "test", Name: "test"},
+				uid:   types.UID("1"),
+				image: "image",
+				rawConfig: json.RawMessage(`
+					{
+						"datastoreEngine": "cockroachdb"
+					}
+				`),
+				secret: &corev1.Secret{Data: map[string][]byte{
+					"datastore_uri": []byte("uri"),
+					"preshared_key": []byte("psk"),
+				}},
+			},
+			wantWarnings: []error{fmt.Errorf("no TLS configured, consider setting \"tlsSecretName\"")},
+			want: &Config{
+				MigrationConfig: MigrationConfig{
+					LogLevel:           "info",
+					DatastoreEngine:    "cockroachdb",
+					DatastoreURI:       "uri",
+					TargetSpiceDBImage: "image",
+					EnvPrefix:          "SPICEDB_",
+					SpiceDBCmd:         "spicedb",
+				},
+				SpiceConfig: SpiceConfig{
+					SkipMigrations: false,
+					Name:           "test",
+					Namespace:      "test",
+					UID:            "1",
+					Replicas:       2,
+					PresharedKey:   "psk",
+					EnvPrefix:      "SPICEDB_",
+					SpiceDBCmd:     "spicedb",
+					Passthrough: map[string]string{
+						"datastoreEngine":        "cockroachdb",
+						"dispatchClusterEnabled": "true",
+					},
+				},
+			},
+		},
+		{
+			name: "set replicas as int",
+			args: args{
+				nn:    types.NamespacedName{Namespace: "test", Name: "test"},
+				uid:   types.UID("1"),
+				image: "image",
+				rawConfig: json.RawMessage(`
+					{
+						"datastoreEngine": "cockroachdb",
+						"replicas": 3
+					}
+				`),
+				secret: &corev1.Secret{Data: map[string][]byte{
+					"datastore_uri": []byte("uri"),
+					"preshared_key": []byte("psk"),
+				}},
+			},
+			wantWarnings: []error{fmt.Errorf("no TLS configured, consider setting \"tlsSecretName\"")},
+			want: &Config{
+				MigrationConfig: MigrationConfig{
+					LogLevel:           "info",
+					DatastoreEngine:    "cockroachdb",
+					DatastoreURI:       "uri",
+					TargetSpiceDBImage: "image",
+					EnvPrefix:          "SPICEDB_",
+					SpiceDBCmd:         "spicedb",
+				},
+				SpiceConfig: SpiceConfig{
+					SkipMigrations: false,
+					Name:           "test",
+					Namespace:      "test",
+					UID:            "1",
+					Replicas:       3,
+					PresharedKey:   "psk",
+					EnvPrefix:      "SPICEDB_",
+					SpiceDBCmd:     "spicedb",
+					Passthrough: map[string]string{
+						"datastoreEngine":        "cockroachdb",
+						"dispatchClusterEnabled": "true",
+					},
+				},
+			},
+		},
+		{
+			name: "set replicas as string",
+			args: args{
+				nn:    types.NamespacedName{Namespace: "test", Name: "test"},
+				uid:   types.UID("1"),
+				image: "image",
+				rawConfig: json.RawMessage(`
+					{
+						"datastoreEngine": "cockroachdb",
+						"replicas": "3"
+					}
+				`),
+				secret: &corev1.Secret{Data: map[string][]byte{
+					"datastore_uri": []byte("uri"),
+					"preshared_key": []byte("psk"),
+				}},
+			},
+			wantWarnings: []error{fmt.Errorf("no TLS configured, consider setting \"tlsSecretName\"")},
+			want: &Config{
+				MigrationConfig: MigrationConfig{
+					LogLevel:           "info",
+					DatastoreEngine:    "cockroachdb",
+					DatastoreURI:       "uri",
+					TargetSpiceDBImage: "image",
+					EnvPrefix:          "SPICEDB_",
+					SpiceDBCmd:         "spicedb",
+				},
+				SpiceConfig: SpiceConfig{
+					SkipMigrations: false,
+					Name:           "test",
+					Namespace:      "test",
+					UID:            "1",
+					Replicas:       3,
+					PresharedKey:   "psk",
+					EnvPrefix:      "SPICEDB_",
+					SpiceDBCmd:     "spicedb",
+					Passthrough: map[string]string{
+						"datastoreEngine":        "cockroachdb",
+						"dispatchClusterEnabled": "true",
+					},
+				},
+			},
+		},
+		{
+			name: "set extra labels as string",
+			args: args{
+				nn:    types.NamespacedName{Namespace: "test", Name: "test"},
+				uid:   types.UID("1"),
+				image: "image",
+				rawConfig: json.RawMessage(`
+					{
+						"datastoreEngine": "cockroachdb",
+						"extraPodLabels": "test=label,other=label"
+					}
+				`),
+				secret: &corev1.Secret{Data: map[string][]byte{
+					"datastore_uri": []byte("uri"),
+					"preshared_key": []byte("psk"),
+				}},
+			},
+			wantWarnings: []error{fmt.Errorf("no TLS configured, consider setting \"tlsSecretName\"")},
+			want: &Config{
+				MigrationConfig: MigrationConfig{
+					LogLevel:           "info",
+					DatastoreEngine:    "cockroachdb",
+					DatastoreURI:       "uri",
+					TargetSpiceDBImage: "image",
+					EnvPrefix:          "SPICEDB_",
+					SpiceDBCmd:         "spicedb",
+				},
+				SpiceConfig: SpiceConfig{
+					SkipMigrations: false,
+					Name:           "test",
+					Namespace:      "test",
+					UID:            "1",
+					Replicas:       2,
+					PresharedKey:   "psk",
+					EnvPrefix:      "SPICEDB_",
+					SpiceDBCmd:     "spicedb",
+					ExtraPodLabels: map[string]string{
+						"test":  "label",
+						"other": "label",
+					},
+					Passthrough: map[string]string{
+						"datastoreEngine":        "cockroachdb",
+						"dispatchClusterEnabled": "true",
+					},
+				},
+			},
+		},
+		{
+			name: "set extra labels as map",
+			args: args{
+				nn:    types.NamespacedName{Namespace: "test", Name: "test"},
+				uid:   types.UID("1"),
+				image: "image",
+				rawConfig: json.RawMessage(`
+					{
+						"datastoreEngine": "cockroachdb",
+						"extraPodLabels": {
+							"test": "label",
+							"other": "label"
+						}
+					}
+				`),
+				secret: &corev1.Secret{Data: map[string][]byte{
+					"datastore_uri": []byte("uri"),
+					"preshared_key": []byte("psk"),
+				}},
+			},
+			wantWarnings: []error{fmt.Errorf("no TLS configured, consider setting \"tlsSecretName\"")},
+			want: &Config{
+				MigrationConfig: MigrationConfig{
+					LogLevel:           "info",
+					DatastoreEngine:    "cockroachdb",
+					DatastoreURI:       "uri",
+					TargetSpiceDBImage: "image",
+					EnvPrefix:          "SPICEDB_",
+					SpiceDBCmd:         "spicedb",
+				},
+				SpiceConfig: SpiceConfig{
+					SkipMigrations: false,
+					Name:           "test",
+					Namespace:      "test",
+					UID:            "1",
+					Replicas:       2,
+					PresharedKey:   "psk",
+					EnvPrefix:      "SPICEDB_",
+					SpiceDBCmd:     "spicedb",
+					ExtraPodLabels: map[string]string{
+						"test":  "label",
+						"other": "label",
+					},
+					Passthrough: map[string]string{
+						"datastoreEngine":        "cockroachdb",
+						"dispatchClusterEnabled": "true",
+					},
+				},
+			},
+		},
+		{
+			name: "skip migrations bool",
+			args: args{
+				nn:    types.NamespacedName{Namespace: "test", Name: "test"},
+				uid:   types.UID("1"),
+				image: "image",
+				rawConfig: json.RawMessage(`
+					{
+						"datastoreEngine": "cockroachdb",
+						"skipMigrations": true	
+					}
+				`),
+				secret: &corev1.Secret{Data: map[string][]byte{
+					"datastore_uri": []byte("uri"),
+					"preshared_key": []byte("psk"),
+				}},
+			},
+			wantWarnings: []error{fmt.Errorf("no TLS configured, consider setting \"tlsSecretName\"")},
+			want: &Config{
+				MigrationConfig: MigrationConfig{
+					LogLevel:               "info",
+					DatastoreEngine:        "cockroachdb",
+					DatastoreURI:           "uri",
+					SpannerCredsSecretRef:  "",
+					TargetSpiceDBImage:     "image",
+					EnvPrefix:              "SPICEDB_",
+					SpiceDBCmd:             "spicedb",
+					DatastoreTLSSecretName: "",
+				},
+				SpiceConfig: SpiceConfig{
+					SkipMigrations: true,
+					Name:           "test",
+					Namespace:      "test",
+					UID:            "1",
+					Replicas:       2,
+					PresharedKey:   "psk",
+					EnvPrefix:      "SPICEDB_",
+					SpiceDBCmd:     "spicedb",
+					Passthrough: map[string]string{
+						"datastoreEngine":        "cockroachdb",
+						"dispatchClusterEnabled": "true",
+					},
+				},
+			},
+		},
+		{
+			name: "skip migrations string",
+			args: args{
+				nn:    types.NamespacedName{Namespace: "test", Name: "test"},
+				uid:   types.UID("1"),
+				image: "image",
+				rawConfig: json.RawMessage(`
+					{
+						"datastoreEngine": "cockroachdb",
+						"skipMigrations": "true"	
+					}
+				`),
+				secret: &corev1.Secret{Data: map[string][]byte{
+					"datastore_uri": []byte("uri"),
+					"preshared_key": []byte("psk"),
+				}},
+			},
+			wantWarnings: []error{fmt.Errorf("no TLS configured, consider setting \"tlsSecretName\"")},
+			want: &Config{
+				MigrationConfig: MigrationConfig{
+					LogLevel:               "info",
+					DatastoreEngine:        "cockroachdb",
+					DatastoreURI:           "uri",
+					SpannerCredsSecretRef:  "",
+					TargetSpiceDBImage:     "image",
+					EnvPrefix:              "SPICEDB_",
+					SpiceDBCmd:             "spicedb",
+					DatastoreTLSSecretName: "",
+				},
+				SpiceConfig: SpiceConfig{
+					SkipMigrations: true,
+					Name:           "test",
+					Namespace:      "test",
+					UID:            "1",
+					Replicas:       2,
+					PresharedKey:   "psk",
+					EnvPrefix:      "SPICEDB_",
+					SpiceDBCmd:     "spicedb",
+					Passthrough: map[string]string{
+						"datastoreEngine":        "cockroachdb",
+						"dispatchClusterEnabled": "true",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotWarning, err := NewConfig(tt.args.nn, tt.args.uid, tt.args.image, tt.args.rawConfig, tt.args.secret)
+			require.Equal(t, tt.want, got)
+			require.EqualValues(t, errors.NewAggregate(tt.wantWarnings), gotWarning)
+			require.EqualValues(t, errors.NewAggregate(tt.wantErrs), err)
 		})
 	}
 }

--- a/pkg/config/keys.go
+++ b/pkg/config/keys.go
@@ -1,0 +1,150 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func newKey[V comparable](k string, defaultValue V) *key[V] {
+	return &key[V]{
+		key:          k,
+		defaultValue: defaultValue,
+	}
+}
+
+func newStringKey(key string) *key[string] {
+	return newKey(key, "")
+}
+
+func (k *key[V]) peek(config RawConfig) any {
+	v, ok := config[k.key]
+	if !ok {
+		return k.defaultValue
+	}
+	return v
+}
+
+func (k *key[V]) pop(config RawConfig) V {
+	v := k.peek(config)
+	delete(config, k.key)
+	tv, ok := v.(V)
+	if !ok {
+		return k.defaultValue
+	}
+
+	return tv
+}
+
+type intOrStringKey struct {
+	key          string
+	defaultValue int64
+}
+
+func newIntOrStringKey(key string, defaultValue int64) *intOrStringKey {
+	return &intOrStringKey{
+		key:          key,
+		defaultValue: defaultValue,
+	}
+}
+
+func (k *intOrStringKey) pop(config RawConfig) (out int64, err error) {
+	v, ok := config[k.key]
+	delete(config, k.key)
+	if !ok {
+		return k.defaultValue, nil
+	}
+
+	switch value := v.(type) {
+	case string:
+		out, err = strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return
+		}
+	case float64:
+		out = int64(value)
+	default:
+		err = fmt.Errorf("expected int or string for key %s", k.key)
+	}
+	return
+}
+
+func (k *intOrStringKey) popDefault(config RawConfig, defaultValue int64) (int64, error) {
+	v, err := k.pop(config)
+	if err != nil {
+		return 0, err
+	}
+	if v == k.defaultValue {
+		return defaultValue, nil
+	}
+	return v, nil
+}
+
+type boolOrStringKey struct {
+	key          string
+	defaultValue bool
+}
+
+func newBoolOrStringKey(key string, defaultValue bool) *boolOrStringKey {
+	return &boolOrStringKey{
+		key:          key,
+		defaultValue: defaultValue,
+	}
+}
+
+func (k *boolOrStringKey) pop(config RawConfig) (out bool, err error) {
+	v, ok := config[k.key]
+	delete(config, k.key)
+	if !ok {
+		return k.defaultValue, nil
+	}
+
+	switch value := v.(type) {
+	case string:
+		out = value == "true"
+	case bool:
+		out = value
+	default:
+		err = fmt.Errorf("expected bool or string for key %s", k.key)
+	}
+	return
+}
+
+type labelSetKey string
+
+func (k labelSetKey) pop(config RawConfig) (podLabels map[string]string, warnings []error, err error) {
+	v, ok := config[string(k)]
+	delete(config, string(k))
+	if !ok {
+		return
+	}
+
+	podLabels = make(map[string]string)
+
+	switch value := v.(type) {
+	case string:
+		if len(value) > 0 {
+			extraPodLabelPairs := strings.Split(value, ",")
+			for _, p := range extraPodLabelPairs {
+				k, v, ok := strings.Cut(p, "=")
+				if !ok {
+					warnings = append(warnings, fmt.Errorf("couldn't parse extra pod label %q: labels should be of the form k=v,k2=v2", p))
+					continue
+				}
+				podLabels[k] = v
+			}
+		}
+	case map[string]any:
+		for k, v := range value {
+			labelValue, ok := v.(string)
+			if !ok {
+				warnings = append(warnings, fmt.Errorf("couldn't parse extra pod label %v", v))
+				continue
+			}
+			podLabels[k] = labelValue
+		}
+	default:
+		err = fmt.Errorf("expected string or map for key %s", k)
+	}
+	return
+}

--- a/pkg/controller/handlers/validate_config.go
+++ b/pkg/controller/handlers/validate_config.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,7 +20,7 @@ const EventInvalidSpiceDBConfig = "InvalidSpiceDBConfig"
 
 type ValidateConfigHandler struct {
 	libctrl.ControlAll
-	rawConfig    map[string]string
+	rawConfig    json.RawMessage
 	spiceDBImage string
 	uid          types.UID
 	generation   int64
@@ -29,7 +30,7 @@ type ValidateConfigHandler struct {
 	next        handler.ContextHandler
 }
 
-func NewValidateConfigHandler(ctrls libctrl.HandlerControls, uid types.UID, rawConfig map[string]string, spicedbImage string, generation int64, status *v1alpha1.ClusterStatus, patchStatus func(ctx context.Context, patch *v1alpha1.SpiceDBCluster) error, recorder record.EventRecorder, next handler.Handler) handler.Handler {
+func NewValidateConfigHandler(ctrls libctrl.HandlerControls, uid types.UID, rawConfig json.RawMessage, spicedbImage string, generation int64, patchStatus func(ctx context.Context, patch *v1alpha1.SpiceDBCluster) error, recorder record.EventRecorder, next handler.Handler) handler.Handler {
 	return handler.NewHandler(&ValidateConfigHandler{
 		ControlAll:   ctrls,
 		uid:          uid,

--- a/pkg/controller/spicedb_handler.go
+++ b/pkg/controller/spicedb_handler.go
@@ -193,7 +193,6 @@ func (r *SpiceDBClusterHandler) validateConfig(next ...handler.Handler) handler.
 		r.cluster.Spec.Config,
 		r.spiceDBImage,
 		r.cluster.Generation,
-		&r.cluster.Status,
 		r.PatchStatus,
 		r.recorder,
 		handler.Handlers(next).MustOne(),

--- a/pkg/libctrl/ensure_component.go
+++ b/pkg/libctrl/ensure_component.go
@@ -87,6 +87,4 @@ func (e *EnsureComponentByHash[K, A]) Handle(ctx context.Context) {
 			}
 		}
 	}
-
-	return
 }

--- a/pkg/libctrl/file_informer_test.go
+++ b/pkg/libctrl/file_informer_test.go
@@ -60,7 +60,7 @@ func TestFileInformer(t *testing.T) {
 
 	// expect an OnUpdate when permission is changed
 	eventHandlers.On("OnUpdate", file.Name(), file.Name()).Return()
-	require.NoError(t, file.Chmod(770))
+	require.NoError(t, file.Chmod(0o770))
 
 	require.Eventually(t, func() bool {
 		eventHandlers.Lock()


### PR DESCRIPTION
Before
```yaml
spec:
  config:
    extraPodLabels: prometheus=scrape-prom
    replicas: "3"
    schemaPrefixesRequired: "true"
```

After:

```yaml
spec:
  config:
    extraPodLabels: 
      prometheus: scrape-prom
    replicas: 3
    schemaPrefixesRequired: true
```

It's also backwards-compatible; both of these forms continue to work.