### PR TITLE
Fix default envPrefix

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,7 +43,7 @@ var (
 	tlsSecretNameKey              = newStringKey("tlsSecretName")
 	dispatchCAKey                 = newStringKey("dispatchUpstreamCASecretName")
 	telemetryCAKey                = newStringKey("telemetryCASecretName")
-	envPrefixKey                  = newKey("envPrefix", "SPICEDB_")
+	envPrefixKey                  = newKey("envPrefix", "SPICEDB")
 	spiceDBCmdKey                 = newKey("cmd", "spicedb")
 	skipMigrationsKey             = newBoolOrStringKey("skipMigrations", false)
 	logLevelKey                   = newKey("logLevel", "info")
@@ -497,6 +497,7 @@ func (c *Config) Deployment(migrationHash string) *applyappsv1.DeploymentApplyCo
 // ToEnvVarName converts a key from the api object into an env var name.
 // the key isCamelCased will be converted to PREFIX_IS_CAMEL_CASED
 func ToEnvVarName(prefix string, key string) string {
+	prefix = strings.TrimSuffix(prefix, "_")
 	envVarParts := []string{strings.ToUpper(prefix)}
 	for _, p := range camelcase.Split(key) {
 		envVarParts = append(envVarParts, strings.ToUpper(p))

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,6 +18,7 @@ func TestToEnvVarName(t *testing.T) {
 		want   string
 	}{
 		{"prefix", "key", "PREFIX_KEY"},
+		{"prefix_", "key", "PREFIX_KEY"},
 		{"SPICEDB", "grpcTLSKeyPath", "SPICEDB_GRPC_TLS_KEY_PATH"},
 		{"SPICEDB", "grpcTlsKeyPath", "SPICEDB_GRPC_TLS_KEY_PATH"},
 		{"SPICEDB", "dispatchUpstreamCAPath", "SPICEDB_DISPATCH_UPSTREAM_CA_PATH"},
@@ -87,7 +88,7 @@ func TestNewConfig(t *testing.T) {
 					DatastoreEngine:    "cockroachdb",
 					DatastoreURI:       "uri",
 					TargetSpiceDBImage: "image",
-					EnvPrefix:          "SPICEDB_",
+					EnvPrefix:          "SPICEDB",
 					SpiceDBCmd:         "spicedb",
 				},
 				SpiceConfig: SpiceConfig{
@@ -97,7 +98,7 @@ func TestNewConfig(t *testing.T) {
 					UID:            "1",
 					Replicas:       2,
 					PresharedKey:   "psk",
-					EnvPrefix:      "SPICEDB_",
+					EnvPrefix:      "SPICEDB",
 					SpiceDBCmd:     "spicedb",
 					Passthrough: map[string]string{
 						"datastoreEngine":        "cockroachdb",
@@ -130,7 +131,7 @@ func TestNewConfig(t *testing.T) {
 					DatastoreEngine:    "cockroachdb",
 					DatastoreURI:       "uri",
 					TargetSpiceDBImage: "image",
-					EnvPrefix:          "SPICEDB_",
+					EnvPrefix:          "SPICEDB",
 					SpiceDBCmd:         "spicedb",
 				},
 				SpiceConfig: SpiceConfig{
@@ -140,7 +141,7 @@ func TestNewConfig(t *testing.T) {
 					UID:            "1",
 					Replicas:       3,
 					PresharedKey:   "psk",
-					EnvPrefix:      "SPICEDB_",
+					EnvPrefix:      "SPICEDB",
 					SpiceDBCmd:     "spicedb",
 					Passthrough: map[string]string{
 						"datastoreEngine":        "cockroachdb",
@@ -173,7 +174,7 @@ func TestNewConfig(t *testing.T) {
 					DatastoreEngine:    "cockroachdb",
 					DatastoreURI:       "uri",
 					TargetSpiceDBImage: "image",
-					EnvPrefix:          "SPICEDB_",
+					EnvPrefix:          "SPICEDB",
 					SpiceDBCmd:         "spicedb",
 				},
 				SpiceConfig: SpiceConfig{
@@ -183,7 +184,7 @@ func TestNewConfig(t *testing.T) {
 					UID:            "1",
 					Replicas:       3,
 					PresharedKey:   "psk",
-					EnvPrefix:      "SPICEDB_",
+					EnvPrefix:      "SPICEDB",
 					SpiceDBCmd:     "spicedb",
 					Passthrough: map[string]string{
 						"datastoreEngine":        "cockroachdb",
@@ -216,7 +217,7 @@ func TestNewConfig(t *testing.T) {
 					DatastoreEngine:    "cockroachdb",
 					DatastoreURI:       "uri",
 					TargetSpiceDBImage: "image",
-					EnvPrefix:          "SPICEDB_",
+					EnvPrefix:          "SPICEDB",
 					SpiceDBCmd:         "spicedb",
 				},
 				SpiceConfig: SpiceConfig{
@@ -226,7 +227,7 @@ func TestNewConfig(t *testing.T) {
 					UID:            "1",
 					Replicas:       2,
 					PresharedKey:   "psk",
-					EnvPrefix:      "SPICEDB_",
+					EnvPrefix:      "SPICEDB",
 					SpiceDBCmd:     "spicedb",
 					ExtraPodLabels: map[string]string{
 						"test":  "label",
@@ -266,7 +267,7 @@ func TestNewConfig(t *testing.T) {
 					DatastoreEngine:    "cockroachdb",
 					DatastoreURI:       "uri",
 					TargetSpiceDBImage: "image",
-					EnvPrefix:          "SPICEDB_",
+					EnvPrefix:          "SPICEDB",
 					SpiceDBCmd:         "spicedb",
 				},
 				SpiceConfig: SpiceConfig{
@@ -276,7 +277,7 @@ func TestNewConfig(t *testing.T) {
 					UID:            "1",
 					Replicas:       2,
 					PresharedKey:   "psk",
-					EnvPrefix:      "SPICEDB_",
+					EnvPrefix:      "SPICEDB",
 					SpiceDBCmd:     "spicedb",
 					ExtraPodLabels: map[string]string{
 						"test":  "label",
@@ -314,7 +315,7 @@ func TestNewConfig(t *testing.T) {
 					DatastoreURI:           "uri",
 					SpannerCredsSecretRef:  "",
 					TargetSpiceDBImage:     "image",
-					EnvPrefix:              "SPICEDB_",
+					EnvPrefix:              "SPICEDB",
 					SpiceDBCmd:             "spicedb",
 					DatastoreTLSSecretName: "",
 				},
@@ -325,7 +326,7 @@ func TestNewConfig(t *testing.T) {
 					UID:            "1",
 					Replicas:       2,
 					PresharedKey:   "psk",
-					EnvPrefix:      "SPICEDB_",
+					EnvPrefix:      "SPICEDB",
 					SpiceDBCmd:     "spicedb",
 					Passthrough: map[string]string{
 						"datastoreEngine":        "cockroachdb",
@@ -359,7 +360,7 @@ func TestNewConfig(t *testing.T) {
 					DatastoreURI:           "uri",
 					SpannerCredsSecretRef:  "",
 					TargetSpiceDBImage:     "image",
-					EnvPrefix:              "SPICEDB_",
+					EnvPrefix:              "SPICEDB",
 					SpiceDBCmd:             "spicedb",
 					DatastoreTLSSecretName: "",
 				},
@@ -370,7 +371,7 @@ func TestNewConfig(t *testing.T) {
 					UID:            "1",
 					Replicas:       2,
 					PresharedKey:   "psk",
-					EnvPrefix:      "SPICEDB_",
+					EnvPrefix:      "SPICEDB",
 					SpiceDBCmd:     "spicedb",
 					Passthrough: map[string]string{
 						"datastoreEngine":        "cockroachdb",


### PR DESCRIPTION
The default was `SPICEDB_` instead of `SPICEDB` which generated bad env var names if you didn't set it explicitly in the SpiceDBCluster spec.

This also normalizes prefixes to remove a trailing `_` if present.