### PR TITLE
support multiple allowed spicedb images

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -89,9 +89,11 @@ var (
 )
 
 type OperatorConfig struct {
-	ImageName   string `json:"imageName"`
-	ImageTag    string `json:"imageTag"`
-	ImageDigest string `json:"imageDigest"`
+	ImageName     string   `json:"imageName"`
+	ImageTag      string   `json:"imageTag"`
+	ImageDigest   string   `json:"imageDigest"`
+	AllowedTags   []string `json:"allowedTags"`
+	AllowedImages []string `json:"allowedImages"`
 }
 
 type Controller struct {
@@ -430,10 +432,12 @@ func (c *Controller) syncOwnedResource(ctx context.Context, gvr schema.GroupVers
 	c.configLock.RLock()
 	// TODO: pull in an image spec library
 	if len(c.config.ImageDigest) > 0 {
-		r.spiceDBImage = strings.Join([]string{c.config.ImageName, c.config.ImageDigest}, "@")
+		r.defaultSpiceDBImage = strings.Join([]string{c.config.ImageName, c.config.ImageDigest}, "@")
 	} else {
-		r.spiceDBImage = strings.Join([]string{c.config.ImageName, c.config.ImageTag}, ":")
+		r.defaultSpiceDBImage = strings.Join([]string{c.config.ImageName, c.config.ImageTag}, ":")
 	}
+	r.allowedSpiceDBImages = c.config.AllowedImages
+	r.allowedSpiceDBTags = c.config.AllowedTags
 	c.configLock.RUnlock()
 
 	r.Handle(ctx)

--- a/pkg/controller/handlers/validate_config.go
+++ b/pkg/controller/handlers/validate_config.go
@@ -20,33 +20,37 @@ const EventInvalidSpiceDBConfig = "InvalidSpiceDBConfig"
 
 type ValidateConfigHandler struct {
 	libctrl.ControlAll
-	rawConfig    json.RawMessage
-	spiceDBImage string
-	uid          types.UID
-	generation   int64
-	recorder     record.EventRecorder
+	rawConfig           json.RawMessage
+	defaultSpiceDBImage string
+	allowedImages       []string
+	allowedTags         []string
+	uid                 types.UID
+	generation          int64
+	recorder            record.EventRecorder
 
 	patchStatus func(ctx context.Context, patch *v1alpha1.SpiceDBCluster) error
 	next        handler.ContextHandler
 }
 
-func NewValidateConfigHandler(ctrls libctrl.HandlerControls, uid types.UID, rawConfig json.RawMessage, spicedbImage string, generation int64, patchStatus func(ctx context.Context, patch *v1alpha1.SpiceDBCluster) error, recorder record.EventRecorder, next handler.Handler) handler.Handler {
+func NewValidateConfigHandler(ctrls libctrl.HandlerControls, uid types.UID, rawConfig json.RawMessage, spicedbImage string, allowedImages, allowedTags []string, generation int64, patchStatus func(ctx context.Context, patch *v1alpha1.SpiceDBCluster) error, recorder record.EventRecorder, next handler.Handler) handler.Handler {
 	return handler.NewHandler(&ValidateConfigHandler{
-		ControlAll:   ctrls,
-		uid:          uid,
-		rawConfig:    rawConfig,
-		spiceDBImage: spicedbImage,
-		generation:   generation,
-		patchStatus:  patchStatus,
-		recorder:     recorder,
-		next:         next,
+		ControlAll:          ctrls,
+		uid:                 uid,
+		rawConfig:           rawConfig,
+		defaultSpiceDBImage: spicedbImage,
+		allowedImages:       allowedImages,
+		allowedTags:         allowedTags,
+		generation:          generation,
+		patchStatus:         patchStatus,
+		recorder:            recorder,
+		next:                next,
 	}, "validateConfig")
 }
 
 func (c *ValidateConfigHandler) Handle(ctx context.Context) {
 	currentStatus := handlercontext.CtxClusterStatus.MustValue(ctx)
 	nn := handlercontext.CtxClusterNN.MustValue(ctx)
-	validatedConfig, warning, err := config.NewConfig(nn, c.uid, []string{c.spiceDBImage}, c.rawConfig, handlercontext.CtxSecret.Value(ctx))
+	validatedConfig, warning, err := config.NewConfig(nn, c.uid, c.defaultSpiceDBImage, c.allowedImages, c.allowedTags, c.rawConfig, handlercontext.CtxSecret.Value(ctx))
 	if err != nil {
 		failedCondition := v1alpha1.NewInvalidConfigCondition("", err)
 		if existing := currentStatus.FindStatusCondition(v1alpha1.ConditionValidatingFailed); existing != nil && existing.Message == failedCondition.Message {

--- a/pkg/controller/handlers/validate_config_test.go
+++ b/pkg/controller/handlers/validate_config_test.go
@@ -218,11 +218,11 @@ func TestValidateConfigHandler(t *testing.T) {
 
 			var called handler.Key
 			h := &ValidateConfigHandler{
-				ControlAll:   ctrls,
-				uid:          "uid",
-				rawConfig:    tt.rawConfig,
-				spiceDBImage: "image",
-				generation:   1,
+				ControlAll:          ctrls,
+				uid:                 "uid",
+				rawConfig:           tt.rawConfig,
+				defaultSpiceDBImage: "image",
+				generation:          1,
 				patchStatus: func(ctx context.Context, patch *v1alpha1.SpiceDBCluster) error {
 					patchCalled = true
 					return nil

--- a/pkg/controller/spicedb_handler.go
+++ b/pkg/controller/spicedb_handler.go
@@ -39,14 +39,16 @@ var v1alpha1ClusterGVR = v1alpha1.SchemeGroupVersion.WithResource(v1alpha1.Spice
 // TODO: wait for a specific RV to be seen, with a timeout
 
 type SpiceDBClusterHandler struct {
-	done         func()
-	requeue      func(duration time.Duration)
-	cluster      *v1alpha1.SpiceDBCluster
-	client       dynamic.Interface
-	kclient      kubernetes.Interface
-	informers    map[schema.GroupVersionResource]dynamicinformer.DynamicSharedInformerFactory
-	recorder     record.EventRecorder
-	spiceDBImage string
+	done                 func()
+	requeue              func(duration time.Duration)
+	cluster              *v1alpha1.SpiceDBCluster
+	client               dynamic.Interface
+	kclient              kubernetes.Interface
+	informers            map[schema.GroupVersionResource]dynamicinformer.DynamicSharedInformerFactory
+	recorder             record.EventRecorder
+	defaultSpiceDBImage  string
+	allowedSpiceDBImages []string
+	allowedSpiceDBTags   []string
 }
 
 // Handle inspects the current SpiceDBCluster object and ensures
@@ -221,7 +223,9 @@ func (r *SpiceDBClusterHandler) validateConfig(next ...handler.Handler) handler.
 		),
 		r.cluster.UID,
 		r.cluster.Spec.Config,
-		r.spiceDBImage,
+		r.defaultSpiceDBImage,
+		r.allowedSpiceDBImages,
+		r.allowedSpiceDBTags,
 		r.cluster.Generation,
 		r.PatchStatus,
 		r.recorder,


### PR DESCRIPTION
Operator config now takes two new fields:

```yaml
allowedTags:
 - v1.8.0
 - v1.9.0
 - v1.10.0@sha256:abcd
 - sha256:efgh
allowedImages:
 - quay.io/authzed/spicedb
 - authzed/spicedb
```

Images set in the spec of the `SpiceDBCluster` are validated against these lists. The existing `imageName`/`imageTag`/`imageDigest` fields are treated as defaults and are used if no image is specified.