### PR TITLE
add controller name to logging middleware

### DIFF
--- a/pkg/controller/spicedb_handler.go
+++ b/pkg/controller/spicedb_handler.go
@@ -57,7 +57,7 @@ func (r *SpiceDBClusterHandler) Handle(ctx context.Context) {
 	ctx = handlercontext.CtxClusterNN.WithValue(ctx, r.cluster.NamespacedName())
 	mw := []libctrl.Middleware{
 		libctrl.MakeMiddleware(middleware.SyncIDMiddleware),
-		libctrl.MakeMiddleware(middleware.KlogMiddleware(klog.KObj(r.cluster))),
+		libctrl.MakeMiddleware(middleware.KlogMiddleware("spicedbcluster", klog.KObj(r.cluster))),
 	}
 	chain := libctrl.ChainWithMiddleware(mw...)
 	parallel := libctrl.ParallelWithMiddleware(mw...)

--- a/pkg/libctrl/middleware/middleware.go
+++ b/pkg/libctrl/middleware/middleware.go
@@ -30,10 +30,10 @@ func SyncIDMiddleware(in handler.Handler) handler.Handler {
 	}, in.ID())
 }
 
-func KlogMiddleware(ref klog.ObjectRef) libctrl.HandlerMiddleware {
+func KlogMiddleware(controllerName string, ref klog.ObjectRef) libctrl.HandlerMiddleware {
 	return func(in handler.Handler) handler.Handler {
 		return handler.NewHandlerFromFunc(func(ctx context.Context) {
-			klog.V(4).InfoS("entering handler", "syncID", CtxSyncID.MustValue(ctx), "object", ref, "handler", in.ID())
+			klog.V(4).InfoS("entering handler", "controller", controllerName, "syncID", CtxSyncID.MustValue(ctx), "object", ref, "handler", in.ID())
 			in.Handle(ctx)
 		}, in.ID())
 	}


### PR DESCRIPTION
in operators with multiple controllers, this makes it clear which log is from which controller.