### PR TITLE
add an option to the operator config for disabling image warnings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -20,7 +20,6 @@ linters:
     - "gosec"
     - "gosimple"
     - "govet"
-    - "ifshort"
     - "importas"
     - "ineffassign"
     - "makezero"

--- a/e2e/cluster_test.go
+++ b/e2e/cluster_test.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/client-go/util/cert"
 
 	"github.com/authzed/spicedb-operator/pkg/apis/authzed/v1alpha1"
-	"github.com/authzed/spicedb-operator/pkg/controller"
+	"github.com/authzed/spicedb-operator/pkg/config"
 	"github.com/authzed/spicedb-operator/pkg/metadata"
 )
 
@@ -725,7 +725,7 @@ var _ = Describe("SpiceDBClusters", func() {
 							var imageName string
 
 							BeforeAll(func() {
-								newConfig := controller.OperatorConfig{
+								newConfig := config.OperatorConfig{
 									ImageTag:  "updated",
 									ImageName: "spicedb",
 								}
@@ -734,7 +734,7 @@ var _ = Describe("SpiceDBClusters", func() {
 							})
 
 							AfterAll(func() {
-								newConfig := controller.OperatorConfig{
+								newConfig := config.OperatorConfig{
 									ImageName: "spicedb",
 									ImageTag:  "dev",
 								}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	clientconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/tools/setup-envtest/env"
 	"sigs.k8s.io/controller-runtime/tools/setup-envtest/remote"
@@ -46,7 +46,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/authzed/spicedb-operator/pkg/cmd/run"
-	"github.com/authzed/spicedb-operator/pkg/controller"
+	"github.com/authzed/spicedb-operator/pkg/config"
 )
 
 func listsep(c rune) bool {
@@ -134,7 +134,7 @@ func StartOperator() {
 	ctx, cancel := context.WithCancel(genericapiserver.SetupSignalContext())
 	DeferCleanup(cancel)
 
-	opconfig := controller.OperatorConfig{
+	opconfig := config.OperatorConfig{
 		ImageName: "spicedb",
 		ImageTag:  "dev",
 	}
@@ -159,7 +159,7 @@ func StartOperator() {
 
 var ConfigFileName = ""
 
-func WriteConfig(operatorConfig controller.OperatorConfig) string {
+func WriteConfig(operatorConfig config.OperatorConfig) string {
 	out, err := yaml.Marshal(operatorConfig)
 	Expect(err).To(Succeed())
 	var file *os.File
@@ -233,7 +233,7 @@ func ConfigureApiserver() {
 
 func ConfigureKube() {
 	var err error
-	restConfig, err = config.GetConfig()
+	restConfig, err = clientconfig.GetConfig()
 
 	// if no kubeconfig or explictly told to provision, provision a cluster
 	if err != nil || provision {

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/atomic v1.7.0
 	go.uber.org/zap v1.23.0
+	golang.org/x/exp v0.0.0-20220823124025-807a23277127
 	google.golang.org/genproto v0.0.0-20220815135757-37a418bb8959
 	k8s.io/api v0.25.0
 	k8s.io/apiextensions-apiserver v0.25.0
@@ -130,7 +131,6 @@ require (
 	go.opentelemetry.io/proto/otlp v0.7.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/exp v0.0.0-20220823124025-807a23277127 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2 // indirect

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -34,13 +34,11 @@ func TestToEnvVarName(t *testing.T) {
 
 func TestNewConfig(t *testing.T) {
 	type args struct {
-		nn            types.NamespacedName
-		uid           types.UID
-		image         string
-		allowedImages []string
-		allowedTags   []string
-		rawConfig     json.RawMessage
-		secret        *corev1.Secret
+		nn           types.NamespacedName
+		uid          types.UID
+		globalConfig OperatorConfig
+		rawConfig    json.RawMessage
+		secret       *corev1.Secret
 	}
 	tests := []struct {
 		name         string
@@ -52,10 +50,12 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "missing required",
 			args: args{
-				nn:            types.NamespacedName{Namespace: "test", Name: "test"},
-				uid:           types.UID("1"),
-				image:         "image",
-				allowedImages: []string{"image"},
+				nn:  types.NamespacedName{Namespace: "test", Name: "test"},
+				uid: types.UID("1"),
+				globalConfig: OperatorConfig{
+					ImageName:     "image",
+					AllowedImages: []string{"image"},
+				},
 				rawConfig: json.RawMessage(`
 					{
 						"test": "field"
@@ -71,10 +71,12 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "simple",
 			args: args{
-				nn:            types.NamespacedName{Namespace: "test", Name: "test"},
-				uid:           types.UID("1"),
-				image:         "image",
-				allowedImages: []string{"image"},
+				nn:  types.NamespacedName{Namespace: "test", Name: "test"},
+				uid: types.UID("1"),
+				globalConfig: OperatorConfig{
+					ImageName:     "image",
+					AllowedImages: []string{"image"},
+				},
 				rawConfig: json.RawMessage(`
 					{
 						"datastoreEngine": "cockroachdb"
@@ -114,10 +116,12 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "memory",
 			args: args{
-				nn:            types.NamespacedName{Namespace: "test", Name: "test"},
-				uid:           types.UID("1"),
-				image:         "image",
-				allowedImages: []string{"image"},
+				nn:  types.NamespacedName{Namespace: "test", Name: "test"},
+				uid: types.UID("1"),
+				globalConfig: OperatorConfig{
+					ImageName:     "image",
+					AllowedImages: []string{"image"},
+				},
 				rawConfig: json.RawMessage(`
 					{
 						"datastoreEngine": "memory"
@@ -156,10 +160,12 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "set supported image",
 			args: args{
-				nn:            types.NamespacedName{Namespace: "test", Name: "test"},
-				uid:           types.UID("1"),
-				image:         "image",
-				allowedImages: []string{"image", "image2"},
+				nn:  types.NamespacedName{Namespace: "test", Name: "test"},
+				uid: types.UID("1"),
+				globalConfig: OperatorConfig{
+					ImageName:     "image",
+					AllowedImages: []string{"image", "image2"},
+				},
 				rawConfig: json.RawMessage(`
 					{
 						"datastoreEngine": "cockroachdb",
@@ -200,11 +206,13 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "set supported tag",
 			args: args{
-				nn:            types.NamespacedName{Namespace: "test", Name: "test"},
-				uid:           types.UID("1"),
-				image:         "image",
-				allowedImages: []string{"image", "other"},
-				allowedTags:   []string{"tag", "tag2", "tag3@sha256:abc", "sha256:abcd"},
+				nn:  types.NamespacedName{Namespace: "test", Name: "test"},
+				uid: types.UID("1"),
+				globalConfig: OperatorConfig{
+					ImageName:     "image",
+					AllowedImages: []string{"image", "other"},
+					AllowedTags:   []string{"tag", "tag2", "tag3@sha256:abc", "sha256:abcd"},
+				},
 				rawConfig: json.RawMessage(`
 					{
 						"datastoreEngine": "cockroachdb",
@@ -245,11 +253,13 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "set supported digest",
 			args: args{
-				nn:            types.NamespacedName{Namespace: "test", Name: "test"},
-				uid:           types.UID("1"),
-				image:         "image",
-				allowedImages: []string{"image", "other"},
-				allowedTags:   []string{"tag", "tag2", "tag3@sha256:abc", "sha256:abcd"},
+				nn:  types.NamespacedName{Namespace: "test", Name: "test"},
+				uid: types.UID("1"),
+				globalConfig: OperatorConfig{
+					ImageName:     "image",
+					AllowedImages: []string{"image", "other"},
+					AllowedTags:   []string{"tag", "tag2", "tag3@sha256:abc", "sha256:abcd"},
+				},
 				rawConfig: json.RawMessage(`
 					{
 						"datastoreEngine": "cockroachdb",
@@ -290,11 +300,13 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "set supported tagless digest",
 			args: args{
-				nn:            types.NamespacedName{Namespace: "test", Name: "test"},
-				uid:           types.UID("1"),
-				image:         "image",
-				allowedImages: []string{"image", "other"},
-				allowedTags:   []string{"tag", "tag2", "tag3@sha256:abc", "sha256:abcd"},
+				nn:  types.NamespacedName{Namespace: "test", Name: "test"},
+				uid: types.UID("1"),
+				globalConfig: OperatorConfig{
+					ImageName:     "image",
+					AllowedImages: []string{"image", "other"},
+					AllowedTags:   []string{"tag", "tag2", "tag3@sha256:abc", "sha256:abcd"},
+				},
 				rawConfig: json.RawMessage(`
 					{
 						"datastoreEngine": "cockroachdb",
@@ -335,11 +347,13 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "set an unsupported image",
 			args: args{
-				nn:            types.NamespacedName{Namespace: "test", Name: "test"},
-				uid:           types.UID("1"),
-				image:         "image",
-				allowedImages: []string{"image"},
-				allowedTags:   []string{"tag"},
+				nn:  types.NamespacedName{Namespace: "test", Name: "test"},
+				uid: types.UID("1"),
+				globalConfig: OperatorConfig{
+					ImageName:     "image",
+					AllowedImages: []string{"image"},
+					AllowedTags:   []string{"tag"},
+				},
 				rawConfig: json.RawMessage(`
 					{
 						"datastoreEngine": "cockroachdb",
@@ -383,11 +397,13 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "set an unsupported tag",
 			args: args{
-				nn:            types.NamespacedName{Namespace: "test", Name: "test"},
-				uid:           types.UID("1"),
-				image:         "image",
-				allowedImages: []string{"image"},
-				allowedTags:   []string{"taggood", "taggood@sha256:abcd"},
+				nn:  types.NamespacedName{Namespace: "test", Name: "test"},
+				uid: types.UID("1"),
+				globalConfig: OperatorConfig{
+					ImageName:     "image",
+					AllowedImages: []string{"image"},
+					AllowedTags:   []string{"taggood", "taggood@sha256:abcd"},
+				},
 				rawConfig: json.RawMessage(`
 					{
 						"datastoreEngine": "cockroachdb",
@@ -431,11 +447,13 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "set an unsupported digest",
 			args: args{
-				nn:            types.NamespacedName{Namespace: "test", Name: "test"},
-				uid:           types.UID("1"),
-				image:         "image",
-				allowedImages: []string{"image"},
-				allowedTags:   []string{"taggood", "taggood@sha256:abcd"},
+				nn:  types.NamespacedName{Namespace: "test", Name: "test"},
+				uid: types.UID("1"),
+				globalConfig: OperatorConfig{
+					ImageName:     "image",
+					AllowedImages: []string{"image"},
+					AllowedTags:   []string{"taggood", "taggood@sha256:abcd"},
+				},
 				rawConfig: json.RawMessage(`
 					{
 						"datastoreEngine": "cockroachdb",
@@ -477,12 +495,64 @@ func TestNewConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "set an unsupported image with validation disabled",
+			args: args{
+				nn:  types.NamespacedName{Namespace: "test", Name: "test"},
+				uid: types.UID("1"),
+				globalConfig: OperatorConfig{
+					DisableImageValidation: true,
+					ImageName:              "image",
+					AllowedImages:          []string{"image"},
+					AllowedTags:            []string{"tag"},
+				},
+				rawConfig: json.RawMessage(`
+					{
+						"datastoreEngine": "cockroachdb",
+						"image": "otherImage:otherTag"
+					}
+				`),
+				secret: &corev1.Secret{Data: map[string][]byte{
+					"datastore_uri": []byte("uri"),
+					"preshared_key": []byte("psk"),
+				}},
+			},
+			wantWarnings: []error{
+				fmt.Errorf("no TLS configured, consider setting \"tlsSecretName\""),
+			},
+			want: &Config{
+				MigrationConfig: MigrationConfig{
+					LogLevel:           "info",
+					DatastoreEngine:    "cockroachdb",
+					DatastoreURI:       "uri",
+					TargetSpiceDBImage: "otherImage:otherTag",
+					EnvPrefix:          "SPICEDB",
+					SpiceDBCmd:         "spicedb",
+				},
+				SpiceConfig: SpiceConfig{
+					SkipMigrations: false,
+					Name:           "test",
+					Namespace:      "test",
+					UID:            "1",
+					Replicas:       2,
+					PresharedKey:   "psk",
+					EnvPrefix:      "SPICEDB",
+					SpiceDBCmd:     "spicedb",
+					Passthrough: map[string]string{
+						"datastoreEngine":        "cockroachdb",
+						"dispatchClusterEnabled": "true",
+					},
+				},
+			},
+		},
+		{
 			name: "set replicas as int",
 			args: args{
-				nn:            types.NamespacedName{Namespace: "test", Name: "test"},
-				uid:           types.UID("1"),
-				image:         "image",
-				allowedImages: []string{"image"},
+				nn:  types.NamespacedName{Namespace: "test", Name: "test"},
+				uid: types.UID("1"),
+				globalConfig: OperatorConfig{
+					ImageName:     "image",
+					AllowedImages: []string{"image"},
+				},
 				rawConfig: json.RawMessage(`
 					{
 						"datastoreEngine": "cockroachdb",
@@ -523,10 +593,12 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "set replicas as string",
 			args: args{
-				nn:            types.NamespacedName{Namespace: "test", Name: "test"},
-				uid:           types.UID("1"),
-				image:         "image",
-				allowedImages: []string{"image"},
+				nn:  types.NamespacedName{Namespace: "test", Name: "test"},
+				uid: types.UID("1"),
+				globalConfig: OperatorConfig{
+					ImageName:     "image",
+					AllowedImages: []string{"image"},
+				},
 				rawConfig: json.RawMessage(`
 					{
 						"datastoreEngine": "cockroachdb",
@@ -567,10 +639,12 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "set extra labels as string",
 			args: args{
-				nn:            types.NamespacedName{Namespace: "test", Name: "test"},
-				uid:           types.UID("1"),
-				image:         "image",
-				allowedImages: []string{"image"},
+				nn:  types.NamespacedName{Namespace: "test", Name: "test"},
+				uid: types.UID("1"),
+				globalConfig: OperatorConfig{
+					ImageName:     "image",
+					AllowedImages: []string{"image"},
+				},
 				rawConfig: json.RawMessage(`
 					{
 						"datastoreEngine": "cockroachdb",
@@ -615,10 +689,12 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "set extra labels as map",
 			args: args{
-				nn:            types.NamespacedName{Namespace: "test", Name: "test"},
-				uid:           types.UID("1"),
-				image:         "image",
-				allowedImages: []string{"image"},
+				nn:  types.NamespacedName{Namespace: "test", Name: "test"},
+				uid: types.UID("1"),
+				globalConfig: OperatorConfig{
+					ImageName:     "image",
+					AllowedImages: []string{"image"},
+				},
 				rawConfig: json.RawMessage(`
 					{
 						"datastoreEngine": "cockroachdb",
@@ -666,10 +742,12 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "skip migrations bool",
 			args: args{
-				nn:            types.NamespacedName{Namespace: "test", Name: "test"},
-				uid:           types.UID("1"),
-				image:         "image",
-				allowedImages: []string{"image"},
+				nn:  types.NamespacedName{Namespace: "test", Name: "test"},
+				uid: types.UID("1"),
+				globalConfig: OperatorConfig{
+					ImageName:     "image",
+					AllowedImages: []string{"image"},
+				},
 				rawConfig: json.RawMessage(`
 					{
 						"datastoreEngine": "cockroachdb",
@@ -712,10 +790,12 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "skip migrations string",
 			args: args{
-				nn:            types.NamespacedName{Namespace: "test", Name: "test"},
-				uid:           types.UID("1"),
-				image:         "image",
-				allowedImages: []string{"image"},
+				nn:  types.NamespacedName{Namespace: "test", Name: "test"},
+				uid: types.UID("1"),
+				globalConfig: OperatorConfig{
+					ImageName:     "image",
+					AllowedImages: []string{"image"},
+				},
 				rawConfig: json.RawMessage(`
 					{
 						"datastoreEngine": "cockroachdb",
@@ -758,7 +838,7 @@ func TestNewConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, gotWarning, err := NewConfig(tt.args.nn, tt.args.uid, tt.args.image, tt.args.allowedImages, tt.args.allowedTags, tt.args.rawConfig, tt.args.secret)
+			got, gotWarning, err := NewConfig(tt.args.nn, tt.args.uid, &tt.args.globalConfig, tt.args.rawConfig, tt.args.secret)
 			require.Equal(t, tt.want, got)
 			require.EqualValues(t, errors.NewAggregate(tt.wantWarnings), gotWarning)
 			require.EqualValues(t, errors.NewAggregate(tt.wantErrs), err)

--- a/pkg/config/global.go
+++ b/pkg/config/global.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"strings"
+
+	"k8s.io/utils/strings/slices"
+)
+
+// OperatorConfig holds operator-wide config that is used across all objects
+type OperatorConfig struct {
+	DisableImageValidation bool     `json:"disableImageValidation"`
+	ImageName              string   `json:"imageName"`
+	ImageTag               string   `json:"imageTag"`
+	ImageDigest            string   `json:"imageDigest"`
+	AllowedTags            []string `json:"allowedTags"`
+	AllowedImages          []string `json:"allowedImages"`
+}
+
+func (o OperatorConfig) DefaultImage() string {
+	if len(o.ImageDigest) > 0 {
+		return strings.Join([]string{o.ImageName, o.ImageDigest}, "@")
+	}
+	if len(o.ImageTag) > 0 {
+		return strings.Join([]string{o.ImageName, o.ImageTag}, ":")
+	}
+	return o.ImageName
+}
+
+func (o OperatorConfig) Copy() OperatorConfig {
+	return OperatorConfig{
+		ImageName:     o.ImageName,
+		ImageTag:      o.ImageTag,
+		ImageDigest:   o.ImageDigest,
+		AllowedTags:   slices.Clone(o.AllowedTags),
+		AllowedImages: slices.Clone(o.AllowedImages),
+	}
+}

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	QueueOps                  = queue.NewQueueOperationsCtx()
-	CtxOperatorConfig         = typedctx.WithDefault[*OperatorConfig](nil)
+	CtxOperatorConfig         = typedctx.WithDefault[*config.OperatorConfig](nil)
 	CtxClusterNN              = typedctx.WithDefault[types.NamespacedName](types.NamespacedName{})
 	CtxSecretNN               = typedctx.WithDefault[types.NamespacedName](types.NamespacedName{})
 	CtxSecret                 = typedctx.WithDefault[*corev1.Secret](nil)

--- a/pkg/controller/validate_config.go
+++ b/pkg/controller/validate_config.go
@@ -42,7 +42,7 @@ func (c *ValidateConfigHandler) Handle(ctx context.Context) {
 	}
 
 	operatorConfig := CtxOperatorConfig.MustValue(ctx)
-	validatedConfig, warning, err := config.NewConfig(nn, CtxCluster.MustValue(ctx).UID, operatorConfig.DefaultImage(), operatorConfig.AllowedImages, operatorConfig.AllowedTags, rawConfig, secret)
+	validatedConfig, warning, err := config.NewConfig(nn, CtxCluster.MustValue(ctx).UID, operatorConfig, rawConfig, secret)
 	if err != nil {
 		failedCondition := v1alpha1.NewInvalidConfigCondition(CtxSecretHash.Value(ctx), err)
 		if existing := currentStatus.FindStatusCondition(v1alpha1.ConditionValidatingFailed); existing != nil && existing.Message == failedCondition.Message {

--- a/pkg/controller/validate_config_test.go
+++ b/pkg/controller/validate_config_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/authzed/controller-idioms/queue/fake"
 
 	"github.com/authzed/spicedb-operator/pkg/apis/authzed/v1alpha1"
+	"github.com/authzed/spicedb-operator/pkg/config"
 )
 
 func TestValidateConfigHandler(t *testing.T) {
@@ -217,7 +218,7 @@ func TestValidateConfigHandler(t *testing.T) {
 			ctx = CtxClusterNN.WithValue(ctx, types.NamespacedName{Namespace: "test", Name: "test"})
 			ctx = CtxClusterStatus.WithValue(ctx, tt.currentStatus)
 			ctx = CtxCluster.WithValue(ctx, &v1alpha1.SpiceDBCluster{Spec: v1alpha1.ClusterSpec{Config: tt.rawConfig}})
-			ctx = CtxOperatorConfig.WithValue(ctx, &OperatorConfig{ImageName: "image", ImageTag: "tag"})
+			ctx = CtxOperatorConfig.WithValue(ctx, &config.OperatorConfig{ImageName: "image", ImageTag: "tag"})
 			var called handler.Key
 			h := &ValidateConfigHandler{
 				patchStatus: func(ctx context.Context, patch *v1alpha1.SpiceDBCluster) error {


### PR DESCRIPTION
The warnings are useful if running a released version of spicedb-operator, but get in the way during testing / CD.