### PR TITLE
Bump goreleaser action to go 1.19

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.18"
+          go-version: "~1.19"
       - uses: "authzed/actions/docker-login@main"
         with:
           quayio_token: "${{ secrets.QUAYIO_PASSWORD }}"


### PR DESCRIPTION
Latest release attempt failed because we use features from 1.19