### PR TITLE
reduce e2e parallelism in GH Actions to 1

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -76,7 +76,7 @@ jobs:
           tags: "spicedb:dev,spicedb:updated"
           outputs: "type=docker,dest=/tmp/image.tar"
       - name: "Run Ginkgo Tests"
-        run: "go run github.com/onsi/ginkgo/v2/ginkgo --skip-package ./spicedb --tags=e2e -r --procs=2 -v --randomize-all --randomize-suites --fail-on-pending --race --trace --json-report=report.json -- -v=4"
+        run: "go run github.com/onsi/ginkgo/v2/ginkgo --skip-package ./spicedb --tags=e2e -r --procs=1 -v --randomize-all --randomize-suites --fail-on-pending --race --trace --json-report=report.json -- -v=4"
         env:
           PROVISION: "true"
           ARCHIVES: "/tmp/image.tar"


### PR DESCRIPTION
we see the e2e test suite flake from time to time in GitHub Actions. This would make the tests last longer, but make sure each test does not have to fight for computational resources