### PR TITLE
Check for secret existence 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,10 @@ go 1.18
 
 require (
 	cloud.google.com/go/spanner v1.37.0
-	github.com/authzed/controller-idioms v0.3.0
+	github.com/authzed/controller-idioms v0.4.0
 	github.com/cespare/xxhash/v2 v2.1.2
 	github.com/fatih/camelcase v1.0.0
+	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3
 	github.com/jzelinskie/stringz v0.0.1
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.5.0
@@ -66,7 +67,6 @@ require (
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/fvbommel/sortorder v1.0.1 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
-	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/authzed/controller-idioms v0.3.0 h1:8veMtvxO67jqwFzxVradPrcZDPBUGmhwwmXAVuPuPus=
-github.com/authzed/controller-idioms v0.3.0/go.mod h1:zfp2hcC4pzMukaQWYZ72jGBMEGpKUV3Y1JGHcCbxwJY=
+github.com/authzed/controller-idioms v0.4.0 h1:YRKfbx2kcAcZEEcpvVs1Xzo3IkZMrZAag3kLD/Y+66o=
+github.com/authzed/controller-idioms v0.4.0/go.mod h1:Ov4P7cMA/CQF7ojBx1Z9dNUp7pAuJviMerp+aRUtUTc=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=

--- a/pkg/apis/authzed/v1alpha1/conditions.go
+++ b/pkg/apis/authzed/v1alpha1/conditions.go
@@ -16,10 +16,13 @@ func (c *SpiceDBCluster) NamespacedName() types.NamespacedName {
 }
 
 const (
-	ConditionTypeValidating     = "Validating"
-	ConditionValidatingFailed   = "ValidatingFailed"
-	ConditionTypeMigrating      = "Migrating"
-	ConditionTypeConfigWarnings = "ConfigurationWarning"
+	ConditionTypeValidating          = "Validating"
+	ConditionValidatingFailed        = "ValidatingFailed"
+	ConditionTypeMigrating           = "Migrating"
+	ConditionTypeConfigWarnings      = "ConfigurationWarning"
+	ConditionTypePreconditionsFailed = "PreconditionsFailed"
+
+	ConditionReasonMissingSecret = "MissingSecret"
 )
 
 func NewValidatingConfigCondition(secretHash string) metav1.Condition {
@@ -64,10 +67,20 @@ func NewMigratingCondition(engine, headRevision string) metav1.Condition {
 
 func NewMigrationFailedCondition(engine, headRevision string, err error) metav1.Condition {
 	return metav1.Condition{
-		Type:               ConditionTypeMigrating, // TODO: constants, etc
+		Type:               ConditionTypeMigrating,
 		Status:             metav1.ConditionFalse,
 		Reason:             "MigrationFailed",
 		LastTransitionTime: metav1.NewTime(time.Now()),
 		Message:            fmt.Sprintf("Migrating %s datastore to %s failed with error: %s", engine, headRevision, err),
+	}
+}
+
+func NewMissingSecretCondition(nn types.NamespacedName) metav1.Condition {
+	return metav1.Condition{
+		Type:               ConditionTypePreconditionsFailed,
+		Status:             metav1.ConditionTrue,
+		Reason:             ConditionReasonMissingSecret,
+		LastTransitionTime: metav1.NewTime(time.Now()),
+		Message:            fmt.Sprintf("Secret %s not found", nn.String()),
 	}
 }

--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/component-base/term"
 	ctrlmanageropts "k8s.io/controller-manager/options"
-	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/klogr"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
 	"github.com/authzed/controller-idioms/manager"
@@ -103,6 +103,8 @@ func (o *Options) Run(ctx context.Context, f cmdutil.Factory) error {
 	}
 	DisableClientRateLimits(restConfig)
 
+	logger := klogr.New()
+
 	dclient, err := dynamic.NewForConfig(restConfig)
 	if err != nil {
 		return err
@@ -114,7 +116,7 @@ func (o *Options) Run(ctx context.Context, f cmdutil.Factory) error {
 	}
 
 	if o.BootstrapCRDs {
-		klog.V(3).InfoS("bootstrapping CRDs")
+		logger.V(3).Info("bootstrapping CRDs")
 		if err := crds.BootstrapCRD(restConfig); err != nil {
 			return err
 		}
@@ -127,6 +129,7 @@ func (o *Options) Run(ctx context.Context, f cmdutil.Factory) error {
 	controllers := make([]manager.Controller, 0)
 	if len(o.BootstrapSpicedbsPath) > 0 {
 		staticSpiceDBController, err := static.NewStaticController[*v1alpha1.SpiceDBCluster](
+			logger,
 			"static-spicedbs",
 			o.BootstrapSpicedbsPath,
 			v1alpha1ClusterGVR,

--- a/pkg/controller/config_change.go
+++ b/pkg/controller/config_change.go
@@ -3,10 +3,9 @@ package controller
 import (
 	"context"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
-
 	"github.com/authzed/controller-idioms/handler"
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/authzed/spicedb-operator/pkg/apis/authzed/v1alpha1"
 )
@@ -29,7 +28,7 @@ func (c *ConfigChangedHandler) Handle(ctx context.Context) {
 	}
 
 	if cluster.GetGeneration() != status.Status.ObservedGeneration || secretHash != status.Status.SecretHash {
-		klog.FromContext(ctx).V(4).Info("spicedb configuration changed")
+		logr.FromContextOrDiscard(ctx).V(4).Info("spicedb configuration changed")
 		status.Status.ObservedGeneration = cluster.GetGeneration()
 		status.Status.SecretHash = secretHash
 		status.SetStatusCondition(v1alpha1.NewValidatingConfigCondition(secretHash))

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/cespare/xxhash/v2"
+	"github.com/go-logr/logr"
 	"go.uber.org/atomic"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -32,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	_ "k8s.io/component-base/metrics/prometheus/workqueue" // for workqueue metric registration
 	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/klogr"
 
 	"github.com/authzed/controller-idioms/adopt"
 	"github.com/authzed/controller-idioms/cachekeys"
@@ -93,6 +95,7 @@ func NewController(ctx context.Context, registry *typed.Registry, dclient dynami
 		kclient: kclient,
 	}
 	c.OwnedResourceController = manager.NewOwnedResourceController(
+		klogr.New(),
 		v1alpha1.SpiceDBClusterResourceName,
 		v1alpha1ClusterGVR,
 		QueueOps,
@@ -101,7 +104,7 @@ func NewController(ctx context.Context, registry *typed.Registry, dclient dynami
 		c.syncOwnedResource,
 	)
 
-	fileInformerFactory, err := fileinformer.NewFileInformerFactory()
+	fileInformerFactory, err := fileinformer.NewFileInformerFactory(klogr.New())
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +117,7 @@ func NewController(ctx context.Context, registry *typed.Registry, dclient dynami
 			DeleteFunc: func(obj interface{}) { c.loadConfig(configFilePath) },
 		})
 	} else {
-		klog.FromContext(ctx).V(3).Info("no operator configuration provided", "path", configFilePath)
+		logr.FromContextOrDiscard(ctx).V(3).Info("no operator configuration provided", "path", configFilePath)
 	}
 
 	ownedInformerFactory := registry.MustNewFilteredDynamicSharedInformerFactory(
@@ -218,7 +221,10 @@ func (c *Controller) loadConfig(path string) {
 	if len(path) == 0 {
 		return
 	}
-	klog.V(3).InfoS("loading config", "path", path)
+
+	logger := klogr.New()
+	logger.V(3).Info("loading config", "path", path)
+
 	file, err := os.Open(path)
 	if err != nil {
 		panic(err)
@@ -248,7 +254,7 @@ func (c *Controller) loadConfig(path string) {
 		return
 	}
 
-	klog.V(3).InfoS("updated config", "path", path, "config", c.config)
+	logger.V(3).Info("updated config", "path", path, "config", c.config)
 
 	// requeue all clusters
 	lister := typed.ListerFor[*v1alpha1.SpiceDBCluster](c.Registry, typed.NewRegistryKey(OwnedFactoryKey, v1alpha1ClusterGVR))
@@ -280,12 +286,12 @@ func (c *Controller) syncOwnedResource(ctx context.Context, gvr schema.GroupVers
 		return
 	}
 
-	logger := klog.LoggerWithValues(klog.Background(),
+	logger := klogr.New().WithValues(
 		"syncID", middleware.NewSyncID(5),
 		"controller", c.Name(),
-		"obj", klog.KObj(cluster),
+		"obj", klog.KObj(cluster).MarshalLog(),
 	)
-	ctx = klog.NewContext(ctx, logger)
+	ctx = logr.NewContext(ctx, logger)
 
 	ctx = CtxCluster.WithValue(ctx, cluster)
 	ctx = CtxClusterStatus.WithValue(ctx, cluster)
@@ -316,7 +322,12 @@ func (c *Controller) syncExternalResource(obj interface{}) {
 		return
 	}
 
-	klog.V(4).InfoS("syncing external object", "obj", klog.KObj(objMeta))
+	logger := klogr.New().WithValues(
+		"syncID", middleware.NewSyncID(5),
+		"controller", c.Name(),
+		"obj", klog.KObj(objMeta),
+	)
+	logger.V(4).Info("syncing external object")
 
 	keys, err := adopt.OwnerKeysFromMeta(metadata.OwnerAnnotationKeyPrefix)(obj)
 	if err != nil {
@@ -338,11 +349,11 @@ func (c *Controller) Handle(ctx context.Context) {
 func (c *Controller) ensureDeployment(next ...handler.Handler) handler.Handler {
 	return handler.NewTypeHandler(&DeploymentHandler{
 		applyDeployment: func(ctx context.Context, dep *applyappsv1.DeploymentApplyConfiguration) (*appsv1.Deployment, error) {
-			klog.FromContext(ctx).V(4).Info("updating deployment", "namespace", *dep.Namespace, "name", *dep.Name)
+			logr.FromContextOrDiscard(ctx).V(4).Info("updating deployment", "namespace", *dep.Namespace, "name", *dep.Name)
 			return c.kclient.AppsV1().Deployments(*dep.Namespace).Apply(ctx, dep, metadata.ApplyForceOwned)
 		},
 		deleteDeployment: func(ctx context.Context, nn types.NamespacedName) error {
-			klog.FromContext(ctx).V(4).Info("deleting deployment", "namespace", nn.Namespace, "name", nn.Name)
+			logr.FromContextOrDiscard(ctx).V(4).Info("deleting deployment", "namespace", nn.Namespace, "name", nn.Name)
 			return c.kclient.AppsV1().Deployments(nn.Namespace).Delete(ctx, nn.Name, metav1.DeleteOptions{})
 		},
 		patchStatus: c.PatchStatus,
@@ -371,11 +382,11 @@ func (c *Controller) cleanupJob(...handler.Handler) handler.Handler {
 			).List(ctx, CtxClusterNN.MustValue(ctx))
 		},
 		deleteJob: func(ctx context.Context, nn types.NamespacedName) error {
-			klog.FromContext(ctx).V(4).Info("deleting job", "namespace", nn.Namespace, "name", nn.Name)
+			logr.FromContextOrDiscard(ctx).V(4).Info("deleting job", "namespace", nn.Namespace, "name", nn.Name)
 			return c.kclient.BatchV1().Jobs(nn.Namespace).Delete(ctx, nn.Name, metav1.DeleteOptions{})
 		},
 		deletePod: func(ctx context.Context, nn types.NamespacedName) error {
-			klog.FromContext(ctx).V(4).Info("deleting job pod", "namespace", nn.Namespace, "name", nn.Name)
+			logr.FromContextOrDiscard(ctx).V(4).Info("deleting job pod", "namespace", nn.Namespace, "name", nn.Name)
 			return c.kclient.CoreV1().Pods(nn.Namespace).Delete(ctx, nn.Name, metav1.DeleteOptions{})
 		},
 	})
@@ -508,11 +519,11 @@ func (c *Controller) ensureServiceAccount(...handler.Handler) handler.Handler {
 		CtxClusterNN,
 		QueueOps.Key,
 		func(ctx context.Context, apply *applycorev1.ServiceAccountApplyConfiguration) (*corev1.ServiceAccount, error) {
-			klog.FromContext(ctx).V(4).Info("applying serviceaccount", "namespace", *apply.Namespace, "name", *apply.Name)
+			logr.FromContextOrDiscard(ctx).V(4).Info("applying serviceaccount", "namespace", *apply.Namespace, "name", *apply.Name)
 			return c.kclient.CoreV1().ServiceAccounts(*apply.Namespace).Apply(ctx, apply, metadata.ApplyForceOwned)
 		},
 		func(ctx context.Context, nn types.NamespacedName) error {
-			klog.FromContext(ctx).V(4).Info("deleting serviceaccount", "namespace", nn.Namespace, "name", nn.Name)
+			logr.FromContextOrDiscard(ctx).V(4).Info("deleting serviceaccount", "namespace", nn.Namespace, "name", nn.Name)
 			return c.kclient.CoreV1().ServiceAccounts(nn.Namespace).Delete(ctx, nn.Name, metav1.DeleteOptions{})
 		},
 		func(ctx context.Context) *applycorev1.ServiceAccountApplyConfiguration {
@@ -538,11 +549,11 @@ func (c *Controller) ensureRole(...handler.Handler) handler.Handler {
 		CtxClusterNN,
 		QueueOps.Key,
 		func(ctx context.Context, apply *applyrbacv1.RoleApplyConfiguration) (*rbacv1.Role, error) {
-			klog.FromContext(ctx).V(4).Info("applying role", "namespace", *apply.Namespace, "name", *apply.Name)
+			logr.FromContextOrDiscard(ctx).V(4).Info("applying role", "namespace", *apply.Namespace, "name", *apply.Name)
 			return c.kclient.RbacV1().Roles(*apply.Namespace).Apply(ctx, apply, metadata.ApplyForceOwned)
 		},
 		func(ctx context.Context, nn types.NamespacedName) error {
-			klog.FromContext(ctx).V(4).Info("deleting role", "namespace", nn.Namespace, "name", nn.Name)
+			logr.FromContextOrDiscard(ctx).V(4).Info("deleting role", "namespace", nn.Namespace, "name", nn.Name)
 			return c.kclient.RbacV1().Roles(nn.Namespace).Delete(ctx, nn.Name, metav1.DeleteOptions{})
 		},
 		func(ctx context.Context) *applyrbacv1.RoleApplyConfiguration {
@@ -569,11 +580,11 @@ func (c *Controller) ensureRoleBinding(next ...handler.Handler) handler.Handler 
 			CtxClusterNN,
 			QueueOps.Key,
 			func(ctx context.Context, apply *applyrbacv1.RoleBindingApplyConfiguration) (*rbacv1.RoleBinding, error) {
-				klog.FromContext(ctx).V(4).Info("applying rolebinding", "namespace", *apply.Namespace, "name", *apply.Name)
+				logr.FromContextOrDiscard(ctx).V(4).Info("applying rolebinding", "namespace", *apply.Namespace, "name", *apply.Name)
 				return c.kclient.RbacV1().RoleBindings(*apply.Namespace).Apply(ctx, apply, metadata.ApplyForceOwned)
 			},
 			func(ctx context.Context, nn types.NamespacedName) error {
-				klog.FromContext(ctx).V(4).Info("deleting rolebinding", "namespace", nn.Namespace, "name", nn.Name)
+				logr.FromContextOrDiscard(ctx).V(4).Info("deleting rolebinding", "namespace", nn.Namespace, "name", nn.Name)
 				return c.kclient.RbacV1().RoleBindings(nn.Namespace).Delete(ctx, nn.Name, metav1.DeleteOptions{})
 			},
 			func(ctx context.Context) *applyrbacv1.RoleBindingApplyConfiguration {
@@ -602,11 +613,11 @@ func (c *Controller) ensureService(...handler.Handler) handler.Handler {
 		CtxClusterNN,
 		QueueOps.Key,
 		func(ctx context.Context, apply *applycorev1.ServiceApplyConfiguration) (*corev1.Service, error) {
-			klog.FromContext(ctx).V(4).Info("applying service", "namespace", *apply.Namespace, "name", *apply.Name)
+			logr.FromContextOrDiscard(ctx).V(4).Info("applying service", "namespace", *apply.Namespace, "name", *apply.Name)
 			return c.kclient.CoreV1().Services(*apply.Namespace).Apply(ctx, apply, metadata.ApplyForceOwned)
 		},
 		func(ctx context.Context, nn types.NamespacedName) error {
-			klog.FromContext(ctx).V(4).Info("deleting service", "namespace", nn.Namespace, "name", nn.Name)
+			logr.FromContextOrDiscard(ctx).V(4).Info("deleting service", "namespace", nn.Namespace, "name", nn.Name)
 			return c.kclient.CoreV1().Services(nn.Namespace).Delete(ctx, nn.Name, metav1.DeleteOptions{})
 		},
 		func(ctx context.Context) *applycorev1.ServiceApplyConfiguration {


### PR DESCRIPTION
Previously, the operator would "adopt" any secret that you put in the `spec` of a `SpiceDBCluster`, even if it didn't exist. This change checks for the existence of the secret before adopting it, and writes out a condition to the status if it can't be found.

Note that the controller will poll the kube api (with backoff & respecting APF responses) indefinitely if a secret can't be found.

This PR also switches to `logr` as a part of updating `controller-idioms` to 0.4.0, but there is no external-facing change.