### PR TITLE
Add required update edges

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -76,7 +76,7 @@ jobs:
           tags: "spicedb:dev,spicedb:updated"
           outputs: "type=docker,dest=/tmp/image.tar"
       - name: "Run Ginkgo Tests"
-        run: "go run github.com/onsi/ginkgo/v2/ginkgo --skip-package ./spicedb --tags=e2e -r --procs=2 -v --randomize-all --randomize-suites --fail-on-pending --race --trace --json-report=report.json -- -v=4"
+        run: "go run github.com/onsi/ginkgo/v2/ginkgo --skip-package ./spicedb --tags=e2e -r --procs=2 -v --randomize-all --randomize-suites --fail-on-pending --fail-fast --no-color --race --trace --json-report=report.json -- -v=4"
         env:
           PROVISION: "true"
           ARCHIVES: "/tmp/image.tar"

--- a/config/crds/authzed.com_spicedbclusters.yaml
+++ b/config/crds/authzed.com_spicedbclusters.yaml
@@ -127,12 +127,19 @@ spec:
               image:
                 description: Image is the image that is or will be used for this cluster
                 type: string
+              migration:
+                description: Migration is the name of the last migration applied
+                type: string
               observedGeneration:
                 description: ObservedGeneration represents the .metadata.generation
                   that has been seen by the controller.
                 format: int64
                 minimum: 0
                 type: integer
+              phase:
+                description: Phase is the currently running phase (used for phased
+                  migrations)
+                type: string
               secretHash:
                 description: SecretHash is a digest of the last applied secret
                 type: string

--- a/e2e/postgresql.yaml
+++ b/e2e/postgresql.yaml
@@ -7,7 +7,7 @@ spec:
   selector:
     matchLabels:
       app: postgresql-db
-  replicas: 2
+  replicas: 1
   template:
     metadata:
       labels:
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: postgresql-db
-          image: postgres:10.20
+          image: postgres:13-alpine
           imagePullPolicy: IfNotPresent
           env:
             - name: POSTGRES_PASSWORD

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/authzed/spicedb-operator
 go 1.18
 
 require (
-	cloud.google.com/go/spanner v1.37.0
+	cloud.google.com/go/spanner v1.39.0
 	github.com/authzed/controller-idioms v0.5.0
 	github.com/cespare/xxhash/v2 v2.1.2
 	github.com/fatih/camelcase v1.0.0
@@ -19,7 +19,7 @@ require (
 	go.uber.org/atomic v1.7.0
 	go.uber.org/zap v1.23.0
 	golang.org/x/exp v0.0.0-20220823124025-807a23277127
-	google.golang.org/genproto v0.0.0-20220815135757-37a418bb8959
+	google.golang.org/genproto v0.0.0-20220916134934-764224ccc2d1
 	k8s.io/api v0.25.0
 	k8s.io/apiextensions-apiserver v0.25.0
 	k8s.io/apimachinery v0.25.0
@@ -132,15 +132,15 @@ require (
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
-	golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2 // indirect
+	golang.org/x/net v0.0.0-20220909164309-bea034e7d591 // indirect
+	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1 // indirect
 	golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde // indirect
-	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
 	golang.org/x/tools v0.1.12 // indirect
-	google.golang.org/api v0.93.0 // indirect
+	google.golang.org/api v0.96.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/grpc v1.48.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2k
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
 cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIAii9o8iA=
 cloud.google.com/go/pubsub v1.3.1/go.mod h1:i+ucay31+CNRpDW4Lu78I4xXG+O1r/MAHgjpRVR+TSU=
-cloud.google.com/go/spanner v1.37.0 h1:eAMgZss33NaXxpEJ+vps6Fu880C3cOYjX1nG3RIRUFE=
-cloud.google.com/go/spanner v1.37.0/go.mod h1:mcbrv+o9VqlUstX83O7YZtJAxDrWFM+B2SrdCb92V5I=
+cloud.google.com/go/spanner v1.39.0 h1:L1APD/LPG+mO54Ts9L+mzwjCfgX8dHjpEObRJAguloE=
+cloud.google.com/go/spanner v1.39.0/go.mod h1:c/JPjc8hsRXHxfgLaxseptOVNHeC4e78xZ7+ajkN/Gk=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
@@ -739,8 +739,9 @@ golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.0.0-20220722155237-a158d28d115b h1:PxfKdU9lEEDYjdIzOtC4qFWgkU2rGHdKlKowJSMN9h0=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.0.0-20220909164309-bea034e7d591 h1:D0B/7al0LLrVC8aWF4+oxpv/m8bc7ViFfVS8/gXGdqI=
+golang.org/x/net v0.0.0-20220909164309-bea034e7d591/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -761,8 +762,9 @@ golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j
 golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20220608161450-d0670ef3b1eb/go.mod h1:jaDAt6Dkxork7LmZnYtzbRWj0W47D86a3TGe0YHBvmE=
-golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2 h1:+jnHzr9VPj32ykQVai5DNahi9+NSp7yYuCsl5eAQtL0=
-golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2/go.mod h1:jaDAt6Dkxork7LmZnYtzbRWj0W47D86a3TGe0YHBvmE=
+golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
+golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1 h1:lxqLZaMad/dJHMFZH0NiNpiEZI/nhgWhe4wgzpE+MuA=
+golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -859,9 +861,9 @@ golang.org/x/sys v0.0.0-20220502124256-b6088ccd6cba/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220624220833-87e55d714810/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 h1:WIoqL4EROvwiPdUtaip4VcDdpZ4kha7wBWZrbVKCIZg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
@@ -991,8 +993,8 @@ google.golang.org/api v0.75.0/go.mod h1:pU9QmyHLnzlpar1Mjt4IbapUCy8J+6HD6GeELN69
 google.golang.org/api v0.78.0/go.mod h1:1Sg78yoMLOhlQTeF+ARBoytAcH1NNyyl390YMy6rKmw=
 google.golang.org/api v0.80.0/go.mod h1:xY3nI94gbvBrE0J6NHXhxOmW97HG7Khjkku6AFB3Hyg=
 google.golang.org/api v0.84.0/go.mod h1:NTsGnUFJMYROtiquksZHBWtHfeMC7iYthki7Eq3pa8o=
-google.golang.org/api v0.93.0 h1:T2xt9gi0gHdxdnRkVQhT8mIvPaXKNsDNWz+L696M66M=
-google.golang.org/api v0.93.0/go.mod h1:+Sem1dnrKlrXMR/X0bPnMWyluQe4RsNoYfmNLhOIkzw=
+google.golang.org/api v0.96.0 h1:F60cuQPJq7K7FzsxMYHAUJSiXh2oKctHxBMbDygxhfM=
+google.golang.org/api v0.96.0/go.mod h1:w7wJQLTM+wvQpNf5JyEcBoxK0RH7EDrh/L4qfsuJ13s=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -1084,8 +1086,8 @@ google.golang.org/genproto v0.0.0-20220608133413-ed9918b62aac/go.mod h1:KEWEmljW
 google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/genproto v0.0.0-20220624142145-8cd45d7dbd1f/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
-google.golang.org/genproto v0.0.0-20220815135757-37a418bb8959 h1:hw4Y42zL1VyVKxPgRHHh191fpVBGV8sNVmcow5Z8VXY=
-google.golang.org/genproto v0.0.0-20220815135757-37a418bb8959/go.mod h1:dbqgFATTzChvnt+ujMdZwITVAJHFtfyN1qUhDqEiIlk=
+google.golang.org/genproto v0.0.0-20220916134934-764224ccc2d1 h1:f+XAjNNl0e5qs8BbB5iQMTYGQjpDbsG4nyAyAuKg3M4=
+google.golang.org/genproto v0.0.0-20220916134934-764224ccc2d1/go.mod h1:0Nb8Qy+Sk5eDzHnzlStwW3itdNaWoZA5XeSG+R3JHSo=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/pkg/apis/authzed/v1alpha1/conditions.go
+++ b/pkg/apis/authzed/v1alpha1/conditions.go
@@ -21,6 +21,7 @@ const (
 	ConditionTypeMigrating           = "Migrating"
 	ConditionTypeConfigWarnings      = "ConfigurationWarning"
 	ConditionTypePreconditionsFailed = "PreconditionsFailed"
+	ConditionTypeRolling             = "RollingDeployment"
 
 	ConditionReasonMissingSecret = "MissingSecret"
 )
@@ -59,7 +60,7 @@ func NewMigratingCondition(engine, headRevision string) metav1.Condition {
 	return metav1.Condition{
 		Type:               ConditionTypeMigrating,
 		Status:             metav1.ConditionTrue,
-		Reason:             "MigratingDatastoreToHead",
+		Reason:             "MigrationJobRunning",
 		LastTransitionTime: metav1.NewTime(time.Now()),
 		Message:            fmt.Sprintf("Migrating %s datastore to %s", engine, headRevision),
 	}
@@ -82,5 +83,15 @@ func NewMissingSecretCondition(nn types.NamespacedName) metav1.Condition {
 		Reason:             ConditionReasonMissingSecret,
 		LastTransitionTime: metav1.NewTime(time.Now()),
 		Message:            fmt.Sprintf("Secret %s not found", nn.String()),
+	}
+}
+
+func NewRollingCondition(message string) metav1.Condition {
+	return metav1.Condition{
+		Type:               ConditionTypeRolling,
+		Status:             metav1.ConditionTrue,
+		Reason:             "WaitingForDeploymentAvailability",
+		LastTransitionTime: metav1.NewTime(time.Now()),
+		Message:            message,
 	}
 }

--- a/pkg/apis/authzed/v1alpha1/types.go
+++ b/pkg/apis/authzed/v1alpha1/types.go
@@ -83,6 +83,12 @@ type ClusterStatus struct {
 	// Image is the image that is or will be used for this cluster
 	Image string `json:"image,omitempty"`
 
+	// Migration is the name of the last migration applied
+	Migration string `json:"migration,omitempty"`
+
+	// Phase is the currently running phase (used for phased migrations)
+	Phase string `json:"phase,omitempty"`
+
 	// Conditions for the current state of the Stack.
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -36,10 +36,11 @@ func TestNewConfig(t *testing.T) {
 	type args struct {
 		nn           types.NamespacedName
 		uid          types.UID
-		currentState *SpiceDBState
+		currentState *SpiceDBMigrationState
 		globalConfig OperatorConfig
 		rawConfig    json.RawMessage
 		secret       *corev1.Secret
+		rolling      bool
 	}
 	tests := []struct {
 		name         string
@@ -931,26 +932,26 @@ func TestNewConfig(t *testing.T) {
 					AllowedImages: []string{"image"},
 					AllowedTags:   []string{"tag", "tag2"},
 					RequiredEdges: map[string]string{
-						SpiceDBState{
+						SpiceDBMigrationState{
 							Tag: "init",
-						}.String(): SpiceDBState{
+						}.String(): SpiceDBMigrationState{
 							Tag: "tag",
 						}.String(),
 					},
-					Nodes: map[string]SpiceDBState{
-						SpiceDBState{
+					Nodes: map[string]SpiceDBMigrationState{
+						SpiceDBMigrationState{
 							Tag: "init",
 						}.String(): {
 							Tag: "init",
 						},
-						SpiceDBState{
+						SpiceDBMigrationState{
 							Tag: "tag",
 						}.String(): {
 							Tag: "tag",
 						},
 					},
 				},
-				currentState: &SpiceDBState{
+				currentState: &SpiceDBMigrationState{
 					Tag: "init",
 				},
 				rawConfig: json.RawMessage(`
@@ -978,7 +979,7 @@ func TestNewConfig(t *testing.T) {
 					EnvPrefix:              "SPICEDB",
 					SpiceDBCmd:             "spicedb",
 					DatastoreTLSSecretName: "",
-					TargetMigration:        "head",
+					TargetMigration:        "",
 				},
 				SpiceConfig: SpiceConfig{
 					LogLevel:       "debug",
@@ -1001,7 +1002,7 @@ func TestNewConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			global := tt.args.globalConfig.Copy()
-			got, gotWarning, err := NewConfig(tt.args.nn, tt.args.uid, tt.args.currentState, &global, tt.args.rawConfig, tt.args.secret)
+			got, gotWarning, err := NewConfig(tt.args.nn, tt.args.uid, tt.args.currentState, &global, tt.args.rawConfig, tt.args.secret, tt.args.rolling)
 			require.Equal(t, tt.want, got)
 			require.EqualValues(t, errors.NewAggregate(tt.wantWarnings), gotWarning)
 			require.EqualValues(t, errors.NewAggregate(tt.wantErrs), err)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -36,7 +36,7 @@ func TestNewConfig(t *testing.T) {
 	type args struct {
 		nn           types.NamespacedName
 		uid          types.UID
-		currentImage string
+		currentState *SpiceDBState
 		globalConfig OperatorConfig
 		rawConfig    json.RawMessage
 		secret       *corev1.Secret
@@ -97,6 +97,7 @@ func TestNewConfig(t *testing.T) {
 					TargetSpiceDBImage: "image",
 					EnvPrefix:          "SPICEDB",
 					SpiceDBCmd:         "spicedb",
+					TargetMigration:    "head",
 				},
 				SpiceConfig: SpiceConfig{
 					LogLevel:       "info",
@@ -142,6 +143,7 @@ func TestNewConfig(t *testing.T) {
 					TargetSpiceDBImage: "image",
 					EnvPrefix:          "SPICEDB",
 					SpiceDBCmd:         "spicedb",
+					TargetMigration:    "head",
 				},
 				SpiceConfig: SpiceConfig{
 					LogLevel:       "info",
@@ -189,6 +191,7 @@ func TestNewConfig(t *testing.T) {
 					TargetSpiceDBImage: "image2",
 					EnvPrefix:          "SPICEDB",
 					SpiceDBCmd:         "spicedb",
+					TargetMigration:    "head",
 				},
 				SpiceConfig: SpiceConfig{
 					LogLevel:       "info",
@@ -237,6 +240,7 @@ func TestNewConfig(t *testing.T) {
 					TargetSpiceDBImage: "other:tag",
 					EnvPrefix:          "SPICEDB",
 					SpiceDBCmd:         "spicedb",
+					TargetMigration:    "head",
 				},
 				SpiceConfig: SpiceConfig{
 					LogLevel:       "info",
@@ -285,6 +289,7 @@ func TestNewConfig(t *testing.T) {
 					TargetSpiceDBImage: "other@sha256:abc",
 					EnvPrefix:          "SPICEDB",
 					SpiceDBCmd:         "spicedb",
+					TargetMigration:    "head",
 				},
 				SpiceConfig: SpiceConfig{
 					LogLevel:       "info",
@@ -333,6 +338,7 @@ func TestNewConfig(t *testing.T) {
 					TargetSpiceDBImage: "other@sha256:abcd",
 					EnvPrefix:          "SPICEDB",
 					SpiceDBCmd:         "spicedb",
+					TargetMigration:    "head",
 				},
 				SpiceConfig: SpiceConfig{
 					LogLevel:       "info",
@@ -384,6 +390,7 @@ func TestNewConfig(t *testing.T) {
 					TargetSpiceDBImage: "otherImage:tag",
 					EnvPrefix:          "SPICEDB",
 					SpiceDBCmd:         "spicedb",
+					TargetMigration:    "head",
 				},
 				SpiceConfig: SpiceConfig{
 					LogLevel:       "info",
@@ -435,6 +442,7 @@ func TestNewConfig(t *testing.T) {
 					TargetSpiceDBImage: "image:tagbad",
 					EnvPrefix:          "SPICEDB",
 					SpiceDBCmd:         "spicedb",
+					TargetMigration:    "head",
 				},
 				SpiceConfig: SpiceConfig{
 					LogLevel:       "info",
@@ -486,6 +494,7 @@ func TestNewConfig(t *testing.T) {
 					TargetSpiceDBImage: "image@sha256:1234",
 					EnvPrefix:          "SPICEDB",
 					SpiceDBCmd:         "spicedb",
+					TargetMigration:    "head",
 				},
 				SpiceConfig: SpiceConfig{
 					LogLevel:       "info",
@@ -537,6 +546,7 @@ func TestNewConfig(t *testing.T) {
 					TargetSpiceDBImage: "otherImage:otherTag",
 					EnvPrefix:          "SPICEDB",
 					SpiceDBCmd:         "spicedb",
+					TargetMigration:    "head",
 				},
 				SpiceConfig: SpiceConfig{
 					LogLevel:       "info",
@@ -584,6 +594,7 @@ func TestNewConfig(t *testing.T) {
 					TargetSpiceDBImage: "image",
 					EnvPrefix:          "SPICEDB",
 					SpiceDBCmd:         "spicedb",
+					TargetMigration:    "head",
 				},
 				SpiceConfig: SpiceConfig{
 					LogLevel:       "info",
@@ -631,6 +642,7 @@ func TestNewConfig(t *testing.T) {
 					TargetSpiceDBImage: "image",
 					EnvPrefix:          "SPICEDB",
 					SpiceDBCmd:         "spicedb",
+					TargetMigration:    "head",
 				},
 				SpiceConfig: SpiceConfig{
 					LogLevel:       "info",
@@ -678,6 +690,7 @@ func TestNewConfig(t *testing.T) {
 					TargetSpiceDBImage: "image",
 					EnvPrefix:          "SPICEDB",
 					SpiceDBCmd:         "spicedb",
+					TargetMigration:    "head",
 				},
 				SpiceConfig: SpiceConfig{
 					LogLevel:       "info",
@@ -732,6 +745,7 @@ func TestNewConfig(t *testing.T) {
 					TargetSpiceDBImage: "image",
 					EnvPrefix:          "SPICEDB",
 					SpiceDBCmd:         "spicedb",
+					TargetMigration:    "head",
 				},
 				SpiceConfig: SpiceConfig{
 					LogLevel:       "info",
@@ -785,6 +799,7 @@ func TestNewConfig(t *testing.T) {
 					EnvPrefix:              "SPICEDB",
 					SpiceDBCmd:             "spicedb",
 					DatastoreTLSSecretName: "",
+					TargetMigration:        "head",
 				},
 				SpiceConfig: SpiceConfig{
 					LogLevel:       "info",
@@ -834,6 +849,7 @@ func TestNewConfig(t *testing.T) {
 					EnvPrefix:              "SPICEDB",
 					SpiceDBCmd:             "spicedb",
 					DatastoreTLSSecretName: "",
+					TargetMigration:        "head",
 				},
 				SpiceConfig: SpiceConfig{
 					LogLevel:       "info",
@@ -885,6 +901,7 @@ func TestNewConfig(t *testing.T) {
 					EnvPrefix:              "SPICEDB",
 					SpiceDBCmd:             "spicedb",
 					DatastoreTLSSecretName: "",
+					TargetMigration:        "head",
 				},
 				SpiceConfig: SpiceConfig{
 					LogLevel:       "debug",
@@ -912,11 +929,30 @@ func TestNewConfig(t *testing.T) {
 					ImageName:     "image",
 					ImageTag:      "init",
 					AllowedImages: []string{"image"},
-					RequiredTagEdges: map[string]string{
-						"init": "tag",
+					AllowedTags:   []string{"tag", "tag2"},
+					RequiredEdges: map[string]string{
+						SpiceDBState{
+							Tag: "init",
+						}.String(): SpiceDBState{
+							Tag: "tag",
+						}.String(),
+					},
+					Nodes: map[string]SpiceDBState{
+						SpiceDBState{
+							Tag: "init",
+						}.String(): {
+							Tag: "init",
+						},
+						SpiceDBState{
+							Tag: "tag",
+						}.String(): {
+							Tag: "tag",
+						},
 					},
 				},
-				currentImage: "image:init",
+				currentState: &SpiceDBState{
+					Tag: "init",
+				},
 				rawConfig: json.RawMessage(`
 					{
 						"logLevel": "debug",
@@ -942,6 +978,7 @@ func TestNewConfig(t *testing.T) {
 					EnvPrefix:              "SPICEDB",
 					SpiceDBCmd:             "spicedb",
 					DatastoreTLSSecretName: "",
+					TargetMigration:        "head",
 				},
 				SpiceConfig: SpiceConfig{
 					LogLevel:       "debug",
@@ -964,7 +1001,7 @@ func TestNewConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			global := tt.args.globalConfig.Copy()
-			got, gotWarning, err := NewConfig(tt.args.nn, tt.args.uid, tt.args.currentImage, &global, tt.args.rawConfig, tt.args.secret)
+			got, gotWarning, err := NewConfig(tt.args.nn, tt.args.uid, tt.args.currentState, &global, tt.args.rawConfig, tt.args.secret)
 			require.Equal(t, tt.want, got)
 			require.EqualValues(t, errors.NewAggregate(tt.wantWarnings), gotWarning)
 			require.EqualValues(t, errors.NewAggregate(tt.wantErrs), err)

--- a/pkg/config/global.go
+++ b/pkg/config/global.go
@@ -10,13 +10,26 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-type SpiceDBState struct {
+type SpiceDBMigrationState struct {
 	Tag       string `json:"tag"`
 	Migration string `json:"migration"`
 	Phase     string `json:"phase"`
 }
 
-func (s SpiceDBState) String() string {
+func (s SpiceDBMigrationState) String() string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("error marshalling state: %w", err).Error()
+	}
+	return fmt.Sprintf("%x", xxhash.Sum64(b))
+}
+
+type SpiceDBDatastoreState struct {
+	Tag       string `json:"tag"`
+	Datastore string `json:"datastore"`
+}
+
+func (s SpiceDBDatastoreState) String() string {
 	b, err := json.Marshal(s)
 	if err != nil {
 		return fmt.Errorf("error marshalling state: %w", err).Error()
@@ -26,14 +39,15 @@ func (s SpiceDBState) String() string {
 
 // OperatorConfig holds operator-wide config that is used across all objects
 type OperatorConfig struct {
-	DisableImageValidation bool                    `json:"disableImageValidation"`
-	ImageName              string                  `json:"imageName"`
-	ImageTag               string                  `json:"imageTag"`
-	ImageDigest            string                  `json:"imageDigest,omitempty"`
-	AllowedTags            []string                `json:"allowedTags"`
-	AllowedImages          []string                `json:"allowedImages"`
-	RequiredEdges          map[string]string       `json:"requiredEdges"`
-	Nodes                  map[string]SpiceDBState `json:"nodes"`
+	DisableImageValidation bool                             `json:"disableImageValidation"`
+	ImageName              string                           `json:"imageName"`
+	ImageTag               string                           `json:"imageTag"`
+	ImageDigest            string                           `json:"imageDigest,omitempty"`
+	AllowedTags            []string                         `json:"allowedTags"`
+	AllowedImages          []string                         `json:"allowedImages"`
+	HeadMigrations         map[string]string                `json:"headMigrations"`
+	RequiredEdges          map[string]string                `json:"requiredEdges"`
+	Nodes                  map[string]SpiceDBMigrationState `json:"nodes"`
 }
 
 func (o OperatorConfig) DefaultImage() string {
@@ -54,6 +68,7 @@ func (o OperatorConfig) Copy() OperatorConfig {
 		ImageDigest:            o.ImageDigest,
 		AllowedTags:            slices.Clone(o.AllowedTags),
 		AllowedImages:          slices.Clone(o.AllowedImages),
+		HeadMigrations:         maps.Clone(o.HeadMigrations),
 		RequiredEdges:          maps.Clone(o.RequiredEdges),
 		Nodes:                  maps.Clone(o.Nodes),
 	}

--- a/pkg/config/global.go
+++ b/pkg/config/global.go
@@ -1,21 +1,39 @@
 package config
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 
+	"github.com/cespare/xxhash/v2"
 	"golang.org/x/exp/maps"
-	"k8s.io/utils/strings/slices"
+	"golang.org/x/exp/slices"
 )
+
+type SpiceDBState struct {
+	Tag       string `json:"tag"`
+	Migration string `json:"migration"`
+	Phase     string `json:"phase"`
+}
+
+func (s SpiceDBState) String() string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("error marshalling state: %w", err).Error()
+	}
+	return fmt.Sprintf("%x", xxhash.Sum64(b))
+}
 
 // OperatorConfig holds operator-wide config that is used across all objects
 type OperatorConfig struct {
-	DisableImageValidation bool              `json:"disableImageValidation"`
-	ImageName              string            `json:"imageName"`
-	ImageTag               string            `json:"imageTag"`
-	ImageDigest            string            `json:"imageDigest,omitempty"`
-	AllowedTags            []string          `json:"allowedTags"`
-	AllowedImages          []string          `json:"allowedImages"`
-	RequiredTagEdges       map[string]string `json:"requiredTagEdges"`
+	DisableImageValidation bool                    `json:"disableImageValidation"`
+	ImageName              string                  `json:"imageName"`
+	ImageTag               string                  `json:"imageTag"`
+	ImageDigest            string                  `json:"imageDigest,omitempty"`
+	AllowedTags            []string                `json:"allowedTags"`
+	AllowedImages          []string                `json:"allowedImages"`
+	RequiredEdges          map[string]string       `json:"requiredEdges"`
+	Nodes                  map[string]SpiceDBState `json:"nodes"`
 }
 
 func (o OperatorConfig) DefaultImage() string {
@@ -36,6 +54,7 @@ func (o OperatorConfig) Copy() OperatorConfig {
 		ImageDigest:            o.ImageDigest,
 		AllowedTags:            slices.Clone(o.AllowedTags),
 		AllowedImages:          slices.Clone(o.AllowedImages),
-		RequiredTagEdges:       maps.Clone(o.RequiredTagEdges),
+		RequiredEdges:          maps.Clone(o.RequiredEdges),
+		Nodes:                  maps.Clone(o.Nodes),
 	}
 }

--- a/pkg/config/global.go
+++ b/pkg/config/global.go
@@ -3,17 +3,19 @@ package config
 import (
 	"strings"
 
+	"golang.org/x/exp/maps"
 	"k8s.io/utils/strings/slices"
 )
 
 // OperatorConfig holds operator-wide config that is used across all objects
 type OperatorConfig struct {
-	DisableImageValidation bool     `json:"disableImageValidation"`
-	ImageName              string   `json:"imageName"`
-	ImageTag               string   `json:"imageTag"`
-	ImageDigest            string   `json:"imageDigest,omitempty"`
-	AllowedTags            []string `json:"allowedTags"`
-	AllowedImages          []string `json:"allowedImages"`
+	DisableImageValidation bool              `json:"disableImageValidation"`
+	ImageName              string            `json:"imageName"`
+	ImageTag               string            `json:"imageTag"`
+	ImageDigest            string            `json:"imageDigest,omitempty"`
+	AllowedTags            []string          `json:"allowedTags"`
+	AllowedImages          []string          `json:"allowedImages"`
+	RequiredTagEdges       map[string]string `json:"requiredTagEdges"`
 }
 
 func (o OperatorConfig) DefaultImage() string {
@@ -34,5 +36,6 @@ func (o OperatorConfig) Copy() OperatorConfig {
 		ImageDigest:            o.ImageDigest,
 		AllowedTags:            slices.Clone(o.AllowedTags),
 		AllowedImages:          slices.Clone(o.AllowedImages),
+		RequiredTagEdges:       maps.Clone(o.RequiredTagEdges),
 	}
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/cespare/xxhash/v2"
@@ -470,11 +471,13 @@ func (c *Controller) validateConfig(next ...handler.Handler) handler.Handler {
 	return handler.NewTypeHandler(&ValidateConfigHandler{
 		patchStatus: c.PatchStatus,
 		recorder:    c.Recorder,
-		getDeploymentImage: func(ctx context.Context, nn types.NamespacedName) (string, error) {
+		getCurrentSpiceDBState: func(ctx context.Context, nn types.NamespacedName) (*config.SpiceDBState, error) {
+			currentState := config.SpiceDBState{}
 			obj, err := lister.ByNamespace(nn.Namespace).Get(nn.Name)
 			if err != nil {
-				return "", err
+				return nil, err
 			}
+			var container corev1.Container
 			var image string
 			for _, c := range obj.Spec.Template.Spec.Containers {
 				// spicedb container name is equal to deployment name
@@ -482,6 +485,7 @@ func (c *Controller) validateConfig(next ...handler.Handler) handler.Handler {
 					continue
 				}
 				image = c.Image
+				container = c
 			}
 
 			// check if deployment is finished rolling out
@@ -489,9 +493,25 @@ func (c *Controller) validateConfig(next ...handler.Handler) handler.Handler {
 				obj.Status.ReadyReplicas == obj.Status.Replicas &&
 				obj.Status.UpdatedReplicas == obj.Status.Replicas &&
 				obj.Status.ObservedGeneration == obj.Generation {
-				return image, nil
+				_, currentState.Tag, _ = config.ExplodeImage(image)
 			}
-			return "", fmt.Errorf("no up-to-date deployment found with correct image")
+
+			// returning an empty state if the deployment is still rolling out
+			// will prevent the next stage from running in multi-step migrations
+			if len(currentState.Tag) == 0 {
+				return nil, fmt.Errorf("no up-to-date deployment found with correct image")
+			}
+
+			if obj.Annotations != nil {
+				currentState.Migration = obj.Annotations[metadata.SpiceDBTargetMigrationKey]
+			}
+
+			for _, e := range container.Env {
+				if strings.HasSuffix(e.Name, "DATASTORE_MIGRATION_PHASE") {
+					currentState.Phase = e.Value
+				}
+			}
+			return &currentState, nil
 		},
 		next: handler.Handlers(next).MustOne(),
 	})

--- a/pkg/controller/ensure_deployment_test.go
+++ b/pkg/controller/ensure_deployment_test.go
@@ -55,7 +55,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			migrationHash: "testtesttesttest",
 			secretHash:    "secret",
 			existingDeployments: []*appsv1.Deployment{{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				metadata.SpiceDBConfigKey: "n8ch568hd8h87h58hdfh8bh565q",
+				metadata.SpiceDBConfigKey: "n678h5dfh674h6fh66chbbh544h667q",
 			}}}},
 			expectNext: nextKey,
 		},
@@ -64,7 +64,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			migrationHash: "testtesttesttest",
 			secretHash:    "secret",
 			existingDeployments: []*appsv1.Deployment{{}, {ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				metadata.SpiceDBConfigKey: "n8ch568hd8h87h58hdfh8bh565q",
+				metadata.SpiceDBConfigKey: "n678h5dfh674h6fh66chbbh544h667q",
 			}}}},
 			expectDelete: true,
 			expectNext:   nextKey,
@@ -74,7 +74,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			migrationHash: "testtesttesttest",
 			secretHash:    "secret1",
 			existingDeployments: []*appsv1.Deployment{{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				metadata.SpiceDBConfigKey: "n687h59dh569h79h54bh67fh67bh7q",
+				metadata.SpiceDBConfigKey: "n678h5dfh674h6fh66chbbh544h667q",
 			}}}},
 			expectApply: true,
 			expectNext:  nextKey,

--- a/pkg/controller/ensure_deployment_test.go
+++ b/pkg/controller/ensure_deployment_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestEnsureDeploymentHandler(t *testing.T) {
+	now := metav1.Now()
 	var nextKey handler.Key = "next"
 	tests := []struct {
 		name string
@@ -27,20 +28,22 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 		secretHash          string
 		existingDeployments []*appsv1.Deployment
 		currentStatus       *v1alpha1.SpiceDBCluster
+		replicas            int32
 
-		expectNext        handler.Key
-		expectStatus      *v1alpha1.SpiceDBCluster
-		expectRequeueErr  error
-		expectApply       bool
-		expectDelete      bool
-		expectPatchStatus bool
+		expectNext         handler.Key
+		expectStatus       *v1alpha1.SpiceDBCluster
+		expectRequeueErr   error
+		expectRequeueAfter bool
+		expectApply        bool
+		expectDelete       bool
+		expectPatchStatus  bool
 	}{
 		{
-			name:          "creates if no deployments",
-			migrationHash: "testtesttesttest",
-			secretHash:    "secret",
-			expectApply:   true,
-			expectNext:    nextKey,
+			name:               "creates if no deployments",
+			migrationHash:      "testtesttesttest",
+			secretHash:         "secret",
+			expectApply:        true,
+			expectRequeueAfter: true,
 		},
 		{
 			name:                "creates if no matching deployment",
@@ -48,7 +51,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			secretHash:          "secret",
 			existingDeployments: []*appsv1.Deployment{{}},
 			expectApply:         true,
-			expectNext:          nextKey,
+			expectRequeueAfter:  true,
 		},
 		{
 			name:          "no-ops if one matching deployment",
@@ -76,8 +79,8 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			existingDeployments: []*appsv1.Deployment{{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
 				metadata.SpiceDBConfigKey: "n678h5dfh674h6fh66chbbh544h667q",
 			}}}},
-			expectApply: true,
-			expectNext:  nextKey,
+			expectApply:        true,
+			expectRequeueAfter: true,
 		},
 		{
 			name: "removes migrating condition if present",
@@ -88,8 +91,74 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			migrationHash:     "testtesttesttest",
 			secretHash:        "secret",
 			expectApply:       true,
-			expectNext:        nextKey,
 			expectPatchStatus: true,
+			expectStatus: &v1alpha1.SpiceDBCluster{Status: v1alpha1.ClusterStatus{Conditions: []metav1.Condition{{
+				Type:               v1alpha1.ConditionTypeRolling,
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: now,
+				Reason:             "WaitingForDeploymentAvailability",
+				Message:            "Rolling deployment to latest version",
+			}}}},
+			expectRequeueAfter: true,
+		},
+		{
+			name: "waits if still rolling out",
+			currentStatus: &v1alpha1.SpiceDBCluster{Status: v1alpha1.ClusterStatus{Conditions: []metav1.Condition{{
+				Type:               v1alpha1.ConditionTypeRolling,
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: now,
+				Reason:             "WaitingForDeploymentAvailability",
+				Message:            "Rolling deployment to latest version",
+			}}}},
+			existingDeployments: []*appsv1.Deployment{{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+					metadata.SpiceDBConfigKey: "n649h99h5cdh579h5cdh568hdh5f5q",
+				}},
+				Status: appsv1.DeploymentStatus{
+					Replicas:          2,
+					UpdatedReplicas:   1,
+					AvailableReplicas: 1,
+					ReadyReplicas:     1,
+				},
+			}},
+			replicas:          2,
+			migrationHash:     "testtesttesttest",
+			secretHash:        "secret",
+			expectPatchStatus: true,
+			expectStatus: &v1alpha1.SpiceDBCluster{Status: v1alpha1.ClusterStatus{Conditions: []metav1.Condition{{
+				Type:               v1alpha1.ConditionTypeRolling,
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: now,
+				Reason:             "WaitingForDeploymentAvailability",
+				Message:            "Waiting for deployment to be available: 1/2 available, 1/2 ready, 1/2 updated, 0/0 generation.",
+			}}}},
+			expectRequeueAfter: true,
+		},
+		{
+			name: "removes rollout status when deployment is available",
+			currentStatus: &v1alpha1.SpiceDBCluster{Status: v1alpha1.ClusterStatus{Conditions: []metav1.Condition{{
+				Type:               v1alpha1.ConditionTypeRolling,
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: now,
+				Reason:             "WaitingForDeploymentAvailability",
+				Message:            "Waiting for deployment to be available: 1/2 available, 1/2 ready, 1/2 updated, 0/0 generation.",
+			}}}},
+			existingDeployments: []*appsv1.Deployment{{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+					metadata.SpiceDBConfigKey: "n649h99h5cdh579h5cdh568hdh5f5q",
+				}},
+				Status: appsv1.DeploymentStatus{
+					Replicas:          2,
+					UpdatedReplicas:   2,
+					AvailableReplicas: 2,
+					ReadyReplicas:     2,
+				},
+			}},
+			replicas:          2,
+			migrationHash:     "testtesttesttest",
+			secretHash:        "secret",
+			expectPatchStatus: true,
+			expectNext:        nextKey,
 			expectStatus:      &v1alpha1.SpiceDBCluster{Status: v1alpha1.ClusterStatus{Conditions: []metav1.Condition{}}},
 		},
 	}
@@ -107,7 +176,10 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 				tt.expectStatus = &v1alpha1.SpiceDBCluster{}
 			}
 
-			ctx := CtxConfig.WithValue(context.Background(), &config.Config{MigrationConfig: config.MigrationConfig{TargetSpiceDBImage: "test"}})
+			ctx := CtxConfig.WithValue(context.Background(), &config.Config{
+				MigrationConfig: config.MigrationConfig{TargetSpiceDBImage: "test"},
+				SpiceConfig:     config.SpiceConfig{Replicas: tt.replicas},
+			})
 			ctx = QueueOps.WithValue(ctx, ctrls)
 			ctx = CtxClusterStatus.WithValue(ctx, tt.currentStatus)
 			ctx = CtxMigrationHash.WithValue(ctx, tt.migrationHash)
@@ -134,7 +206,11 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			}
 			h.Handle(ctx)
 
-			require.Equal(t, tt.expectStatus, CtxClusterStatus.MustValue(ctx))
+			cluster := CtxClusterStatus.MustValue(ctx)
+			for i := range cluster.Status.Conditions {
+				cluster.Status.Conditions[i].LastTransitionTime = now
+			}
+			require.Equal(t, tt.expectStatus, cluster)
 			require.Equal(t, tt.expectApply, applyCalled)
 			require.Equal(t, tt.expectDelete, deleteCalled)
 			require.Equal(t, tt.expectPatchStatus, patchCalled)
@@ -143,6 +219,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 				require.Equal(t, 1, ctrls.RequeueErrCallCount())
 				require.Equal(t, tt.expectRequeueErr, ctrls.RequeueErrArgsForCall(0))
 			}
+			require.Equal(t, tt.expectRequeueAfter, ctrls.RequeueAfterCallCount() == 1)
 		})
 	}
 }

--- a/pkg/controller/run_migration.go
+++ b/pkg/controller/run_migration.go
@@ -26,7 +26,7 @@ func (m *MigrationRunHandler) Handle(ctx context.Context) {
 	// TODO: setting status is unconditional, should happen in a separate handler
 	currentStatus := CtxClusterStatus.MustValue(ctx)
 	config := CtxConfig.MustValue(ctx)
-	currentStatus.SetStatusCondition(v1alpha1.NewMigratingCondition(config.DatastoreEngine, "head"))
+	currentStatus.SetStatusCondition(v1alpha1.NewMigratingCondition(config.DatastoreEngine, config.TargetMigration))
 	if err := m.patchStatus(ctx, currentStatus); err != nil {
 		QueueOps.RequeueErr(ctx, err)
 		return

--- a/pkg/controller/validate_config_test.go
+++ b/pkg/controller/validate_config_test.go
@@ -23,9 +23,10 @@ func TestValidateConfigHandler(t *testing.T) {
 	tests := []struct {
 		name string
 
-		rawConfig      json.RawMessage
-		currentStatus  *v1alpha1.SpiceDBCluster
-		existingSecret *corev1.Secret
+		rawConfig       json.RawMessage
+		currentStatus   *v1alpha1.SpiceDBCluster
+		existingSecret  *corev1.Secret
+		deploymentImage string
 
 		expectNext        handler.Key
 		expectEvents      []string
@@ -224,6 +225,9 @@ func TestValidateConfigHandler(t *testing.T) {
 				patchStatus: func(ctx context.Context, patch *v1alpha1.SpiceDBCluster) error {
 					patchCalled = true
 					return nil
+				},
+				getDeploymentImage: func(ctx context.Context, nn types.NamespacedName) (string, error) {
+					return tt.deploymentImage, nil
 				},
 				recorder: recorder,
 				next: handler.ContextHandlerFunc(func(ctx context.Context) {

--- a/pkg/controller/validate_config_test.go
+++ b/pkg/controller/validate_config_test.go
@@ -26,7 +26,6 @@ func TestValidateConfigHandler(t *testing.T) {
 		rawConfig      json.RawMessage
 		currentStatus  *v1alpha1.SpiceDBCluster
 		existingSecret *corev1.Secret
-		currentState   *config.SpiceDBState
 
 		expectNext        handler.Key
 		expectEvents      []string
@@ -40,8 +39,8 @@ func TestValidateConfigHandler(t *testing.T) {
 			name: "valid config, no changes, no warnings",
 			currentStatus: &v1alpha1.SpiceDBCluster{Status: v1alpha1.ClusterStatus{
 				Image:                "image:tag",
-				TargetMigrationHash:  "n695h689h684h5bbh64h649hfch579q",
-				CurrentMigrationHash: "n695h689h684h5bbh64h649hfch579q",
+				TargetMigrationHash:  "n5dbh8fh58dh5b7h79h599h64bh5dbq",
+				CurrentMigrationHash: "n5dbh8fh58dh5b7h79h599h64bh5dbq",
 			}},
 			rawConfig: json.RawMessage(`{
 				"datastoreEngine": "cockroachdb",
@@ -213,10 +212,6 @@ func TestValidateConfigHandler(t *testing.T) {
 			recorder := record.NewFakeRecorder(1)
 			patchCalled := false
 
-			if tt.currentState == nil {
-				tt.currentState = &config.SpiceDBState{}
-			}
-
 			ctx := context.Background()
 			ctx = QueueOps.WithValue(ctx, ctrls)
 			ctx = CtxSecret.WithValue(ctx, tt.existingSecret)
@@ -229,9 +224,6 @@ func TestValidateConfigHandler(t *testing.T) {
 				patchStatus: func(ctx context.Context, patch *v1alpha1.SpiceDBCluster) error {
 					patchCalled = true
 					return nil
-				},
-				getCurrentSpiceDBState: func(ctx context.Context, nn types.NamespacedName) (*config.SpiceDBState, error) {
-					return tt.currentState, nil
 				},
 				recorder: recorder,
 				next: handler.ContextHandlerFunc(func(ctx context.Context) {

--- a/pkg/crds/authzed.com_spicedbclusters.yaml
+++ b/pkg/crds/authzed.com_spicedbclusters.yaml
@@ -127,12 +127,19 @@ spec:
               image:
                 description: Image is the image that is or will be used for this cluster
                 type: string
+              migration:
+                description: Migration is the name of the last migration applied
+                type: string
               observedGeneration:
                 description: ObservedGeneration represents the .metadata.generation
                   that has been seen by the controller.
                 format: int64
                 minimum: 0
                 type: integer
+              phase:
+                description: Phase is the currently running phase (used for phased
+                  migrations)
+                type: string
               secretHash:
                 description: SecretHash is a digest of the last applied secret
                 type: string

--- a/pkg/metadata/keys.go
+++ b/pkg/metadata/keys.go
@@ -30,6 +30,7 @@ const (
 	ComponentServiceLabel           = "spicedb-service"
 	ComponentRoleBindingLabel       = "spicedb-rolebinding"
 	SpiceDBMigrationRequirementsKey = "authzed.com/spicedb-migration"
+	SpiceDBTargetMigrationKey       = "authzed.com/spicedb-target-migration"
 	SpiceDBSecretRequirementsKey    = "authzed.com/spicedb-secret" // nolint: gosec
 	SpiceDBConfigKey                = "authzed.com/spicedb-configuration"
 	FieldManager                    = "spicedb-operator"


### PR DESCRIPTION
This adds three new fields to the operator config file:

- `nodes`, a map from a hash to a particular spicedb deployment config (`tag`, `migration`, and `phase`
- `requiredEdges` a map from node hash to node hash.
- `headMigrations` a map from tag+datastore to the name of the head migration for that release

If the spec of a `SpiceDBCluster` is changed, and the currently running config matches the key of something in the `requiredEdge` map, then the node pointed to by the value of the `requiredEdge` map will be deployed instead.

Example of `SpiceDBCluster` statuses as it walks through a required update flow: https://gist.github.com/ecordell/8ede43054caa3694623a5a16a158ed38

TODO:
- [ ] Update `generate-allowed-images` to output required edges as well (including required edges from everything before the required migration)