### PR TITLE
default target migration to `head` if it is otherwise unset

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -372,7 +372,10 @@ func computeTargets(image, engine string, currentState *SpiceDBMigrationState, g
 	// if already migrating or rolling, use current state
 	if rolling {
 		targetImage = specBaseImage + ":" + currentState.Tag
-		targetMigration = currentState.Migration
+		// if the migration is set, use that
+		if len(currentState.Migration) > 0 {
+			targetMigration = currentState.Migration
+		}
 		targetPhase = currentState.Phase
 		return
 	}


### PR DESCRIPTION
If upgrading from a version of the operator that doesn't write the migration name into the status, the `currentMigration` will be `""` - the operator prefers this value, so it is possible to run migrations that run `spicedb migrate __` with no migration name, which will fail.