### PR TITLE
pkg/updates: move logic into graph methods

### DIFF
--- a/pkg/updates/file.go
+++ b/pkg/updates/file.go
@@ -2,8 +2,12 @@ package updates
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/jzelinskie/stringz"
 	"golang.org/x/exp/slices"
+
+	"github.com/authzed/spicedb-operator/pkg/apis/authzed/v1alpha1"
 )
 
 // Channel is a named series of updates in which we expect to have a path
@@ -64,4 +68,189 @@ func (g *UpdateGraph) SourceForChannel(channel string) (Source, error) {
 // the graph doesn't change during a single reconciliation.
 func (g *UpdateGraph) Copy() UpdateGraph {
 	return UpdateGraph{Channels: slices.Clone(g.Channels)}
+}
+
+// AvailableVersions traverses an UpdateGraph and collects a list of the
+// safe versions for updating from the provided version.
+func (g *UpdateGraph) AvailableVersions(engine string, v v1alpha1.SpiceDBVersion) ([]v1alpha1.SpiceDBVersion, error) {
+	source, err := g.SourceForChannel(v.Channel)
+	if err != nil {
+		return nil, fmt.Errorf("no source found for channel %q, can't compute available versions: %w", v.Channel, err)
+	}
+
+	availableVersions := make([]v1alpha1.SpiceDBVersion, 0)
+	nextWithoutMigrations := source.NextVersionWithoutMigrations(v.Name)
+	latest := source.LatestVersion(v.Name)
+	if len(nextWithoutMigrations) > 0 {
+		nextDirectVersion := v1alpha1.SpiceDBVersion{
+			Name:        nextWithoutMigrations,
+			Channel:     v.Channel,
+			Description: "direct update with no migrations",
+		}
+		if nextWithoutMigrations == latest {
+			nextDirectVersion.Description += ", head of channel"
+		}
+		availableVersions = append(availableVersions, nextDirectVersion)
+	}
+
+	next := source.NextVersion(v.Name)
+	if len(next) > 0 && next != nextWithoutMigrations {
+		nextVersion := v1alpha1.SpiceDBVersion{
+			Name:        next,
+			Channel:     v.Channel,
+			Description: "update will run a migration",
+		}
+		if next == latest {
+			nextVersion.Description += ", head of channel"
+		}
+		availableVersions = append(availableVersions, nextVersion)
+	}
+	if len(latest) > 0 && next != latest && nextWithoutMigrations != latest {
+		availableVersions = append(availableVersions, v1alpha1.SpiceDBVersion{
+			Name:        latest,
+			Channel:     v.Channel,
+			Description: "head of the channel, multiple updates will run in sequence",
+		})
+	}
+
+	// Check for options in other channels, but only show the safest update for
+	// for each available channel.
+	for _, c := range g.Channels {
+		if c.Name == v.Channel {
+			continue
+		}
+		if c.Metadata["datastore"] != engine {
+			continue
+		}
+		source, err := g.SourceForChannel(c.Name)
+		if err != nil {
+			continue
+		}
+		if next := source.NextVersionWithoutMigrations(v.Name); len(next) > 0 {
+			availableVersions = append(availableVersions, v1alpha1.SpiceDBVersion{
+				Name:        next,
+				Channel:     c.Name,
+				Description: "direct update with no migrations, different channel",
+			})
+			continue
+		}
+		if next := source.NextVersion(v.Name); len(next) > 0 {
+			availableVersions = append(availableVersions, v1alpha1.SpiceDBVersion{
+				Name:        next,
+				Channel:     c.Name,
+				Description: "update will run a migration, different channel",
+			})
+		}
+	}
+
+	return availableVersions, nil
+}
+
+func explodeImage(image string) (baseImage, tag, digest string) {
+	imageMaybeTag, digest, hasDigest := strings.Cut(image, "@")
+	if !hasDigest {
+		digest = ""
+	}
+	baseImage, tag, hasTag := strings.Cut(imageMaybeTag, ":")
+	if !hasTag {
+		tag = ""
+	}
+	return
+}
+
+// ComputeTarget determines the target update version and state given an update
+// graph and the proper context.
+func (g *UpdateGraph) ComputeTarget(defaultBaseImage, image, version, channel, engine string, currentVersion *v1alpha1.SpiceDBVersion, rolling bool) (baseImage string, target *v1alpha1.SpiceDBVersion, state State, err error) {
+	baseImage, tag, digest := explodeImage(image)
+
+	// If digest or tag are set, don't use an update graph.
+	if len(digest) > 0 || len(tag) > 0 {
+		state = State{Tag: tag, Digest: digest}
+		return
+	}
+
+	// Fallback to the default base image if none is set.
+	baseImage = stringz.DefaultEmpty(baseImage, defaultBaseImage)
+	if baseImage == "" {
+		err = fmt.Errorf("no base image in operator config, and none specified in image")
+		return
+	}
+
+	// Fallback to the channel from the current version.
+	if channel == "" && currentVersion != nil {
+		channel = currentVersion.Channel
+	}
+
+	// If there's no still no channel, pick a default based on the engine.
+	if channel == "" {
+		channel, err = g.ChannelForDatastore(engine)
+		if err != nil {
+			err = fmt.Errorf("couldn't find channel for datastore %q: %w", engine, err)
+			return
+		}
+	}
+
+	var updateSource Source
+	if len(channel) > 0 {
+		updateSource, err = g.SourceForChannel(channel)
+		if err != nil {
+			err = fmt.Errorf("error fetching update source: %w", err)
+			return
+		}
+	}
+
+	// Default to the version we're working toward.
+	target = currentVersion
+
+	var currentState State
+	if currentVersion != nil {
+		currentState = updateSource.State(currentVersion.Name)
+	}
+
+	// If cluster is rolling, return the current state as reported by the status
+	// and update graph.
+	//
+	// TODO(ecordell): This can change if the update graph is modified - do we
+	// want to actually return status.image/etc?
+	if rolling {
+		if len(currentState.ID) == 0 {
+			err = fmt.Errorf("cluster is rolling out, but no current state is defined")
+			return
+		}
+		state = currentState
+		return
+	}
+
+	// If version is set, we only use the subset of the update graph that leads
+	// to that version.
+	if len(version) > 0 {
+		updateSource, err = updateSource.Subgraph(version)
+		if err != nil {
+			err = fmt.Errorf("error finding update path from %s to %s", currentVersion.Name, version)
+			return
+		}
+	}
+
+	var targetVersion string
+	if currentVersion != nil && len(currentVersion.Name) > 0 {
+		targetVersion = updateSource.NextVersion(currentVersion.Name)
+		if len(targetVersion) == 0 {
+			// There's no next version, so use the current state.
+			state = currentState
+			target = currentVersion
+			return
+		}
+	} else {
+		// There's no current version, so install head.
+		// TODO(jzelinskie): find a way to make this less "magical"
+		targetVersion = updateSource.LatestVersion("")
+	}
+
+	// If we found the next step to take, return it.
+	state = updateSource.State(targetVersion)
+	target = &v1alpha1.SpiceDBVersion{
+		Name:    state.ID,
+		Channel: channel,
+	}
+	return
 }

--- a/pkg/updates/file.go
+++ b/pkg/updates/file.go
@@ -47,7 +47,7 @@ type UpdateGraph struct {
 // provided. In the future we may want to explicitly define default channels.
 func (g *UpdateGraph) ChannelForDatastore(datastore string) (string, error) {
 	for _, c := range g.Channels {
-		if c.Metadata["datastore"] == datastore {
+		if strings.EqualFold(c.Metadata["datastore"], datastore) {
 			return c.Name, nil
 		}
 	}
@@ -57,7 +57,7 @@ func (g *UpdateGraph) ChannelForDatastore(datastore string) (string, error) {
 // SourceForChannel returns a channel represented as a Source for querying
 func (g *UpdateGraph) SourceForChannel(channel string) (Source, error) {
 	for _, c := range g.Channels {
-		if c.Name == channel {
+		if strings.EqualFold(c.Name, channel) {
 			return NewMemorySource(c.Nodes, c.Edges)
 		}
 	}

--- a/pkg/updates/file_test.go
+++ b/pkg/updates/file_test.go
@@ -78,7 +78,7 @@ func TestAvailableVersions(t *testing.T) {
 			engine:        "cockroachdb",
 			version:       v1alpha1.SpiceDBVersion{Name: "v1.0.0", Channel: "cockroachdb"},
 			expectedNames: nil,
-			expectedErr:   "no edges or no nodes",
+			expectedErr:   "missing edges",
 		},
 		{
 			name: "graph without nodes",
@@ -90,7 +90,7 @@ func TestAvailableVersions(t *testing.T) {
 			engine:        "cockroachdb",
 			version:       v1alpha1.SpiceDBVersion{Name: "v1.0.0", Channel: "cockroachdb"},
 			expectedNames: nil,
-			expectedErr:   "no edges or no nodes",
+			expectedErr:   "missing nodes",
 		},
 		{
 			name: "simple patch update",

--- a/pkg/updates/file_test.go
+++ b/pkg/updates/file_test.go
@@ -1,0 +1,338 @@
+package updates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb-operator/pkg/apis/authzed/v1alpha1"
+)
+
+func TestChannelForDatastore(t *testing.T) {
+	graph := UpdateGraph{Channels: []Channel{
+		{
+			Name:     "postgres",
+			Metadata: map[string]string{"datastore": "postgres"},
+			Nodes:    []State{{ID: "v1.0.0"}},
+		},
+		{
+			Name:     "cockroachdb",
+			Metadata: map[string]string{"datastore": "cockroachdb"},
+			Nodes:    []State{{ID: "v1.0.0"}},
+		},
+	}}
+
+	t.Run("common case", func(t *testing.T) {
+		channel, err := graph.ChannelForDatastore("cockroachdb")
+		require.Nil(t, err)
+		require.Equal(t, "cockroachdb", channel)
+
+		channel, err = graph.ChannelForDatastore("postgres")
+		require.Nil(t, err)
+		require.Equal(t, "postgres", channel)
+	})
+
+	t.Run("case insensitive", func(t *testing.T) {
+		channel, err := graph.ChannelForDatastore("POSTGRES")
+		require.Nil(t, err)
+		require.Equal(t, "postgres", channel)
+	})
+}
+
+func TestAvailableVersions(t *testing.T) {
+	table := []struct {
+		name          string
+		graph         *UpdateGraph
+		engine        string
+		version       v1alpha1.SpiceDBVersion
+		expectedNames []string
+		expectedErr   string
+	}{
+		{
+			name:          "empty graph",
+			graph:         &UpdateGraph{},
+			engine:        "postgres",
+			version:       v1alpha1.SpiceDBVersion{Name: "v1.0.0", Channel: "postgres"},
+			expectedNames: nil,
+			expectedErr:   `no source found for channel "postgres"`,
+		},
+		{
+			name: "graph without matching channel",
+			graph: &UpdateGraph{Channels: []Channel{{
+				Name:     "cockroachdb",
+				Metadata: map[string]string{"datastore": "cockroachdb"},
+				Nodes:    []State{{ID: "v1.0.0"}},
+			}}},
+			engine:        "postgres",
+			version:       v1alpha1.SpiceDBVersion{Name: "v1.0.0", Channel: "postgres"},
+			expectedNames: nil,
+			expectedErr:   `no source found for channel "postgres"`,
+		},
+		{
+			name: "graph without edges",
+			graph: &UpdateGraph{Channels: []Channel{{
+				Name:     "cockroachdb",
+				Metadata: map[string]string{"datastore": "cockroachdb"},
+				Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
+			}}},
+			engine:        "cockroachdb",
+			version:       v1alpha1.SpiceDBVersion{Name: "v1.0.0", Channel: "cockroachdb"},
+			expectedNames: nil,
+			expectedErr:   "no edges or no nodes",
+		},
+		{
+			name: "graph without nodes",
+			graph: &UpdateGraph{Channels: []Channel{{
+				Name:     "cockroachdb",
+				Metadata: map[string]string{"datastore": "cockroachdb"},
+				Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}},
+			}}},
+			engine:        "cockroachdb",
+			version:       v1alpha1.SpiceDBVersion{Name: "v1.0.0", Channel: "cockroachdb"},
+			expectedNames: nil,
+			expectedErr:   "no edges or no nodes",
+		},
+		{
+			name: "simple patch update",
+			graph: &UpdateGraph{Channels: []Channel{{
+				Name:     "cockroachdb",
+				Metadata: map[string]string{"datastore": "cockroachdb"},
+				Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}},
+				Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
+			}}},
+			engine:        "cockroachdb",
+			version:       v1alpha1.SpiceDBVersion{Name: "v1.0.0", Channel: "cockroachdb"},
+			expectedNames: []string{"v1.0.1"},
+		},
+		{
+			name: "head returns nothing",
+			graph: &UpdateGraph{Channels: []Channel{{
+				Name:     "cockroachdb",
+				Metadata: map[string]string{"datastore": "cockroachdb"},
+				Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}},
+				Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
+			}}},
+			engine:        "cockroachdb",
+			version:       v1alpha1.SpiceDBVersion{Name: "v1.0.1", Channel: "cockroachdb"},
+			expectedNames: []string{},
+		},
+		{
+			name: "ignores old versions",
+			graph: &UpdateGraph{Channels: []Channel{{
+				Name:     "cockroachdb",
+				Metadata: map[string]string{"datastore": "cockroachdb"},
+				Edges: EdgeSet{
+					"v1.0.0": {"v1.0.1", "v1.1.0"},
+					"v1.0.1": {"v1.1.0"},
+				},
+				Nodes: []State{{ID: "v1.1.0"}, {ID: "v1.0.1"}, {ID: "v1.0.0"}},
+			}}},
+			engine:        "cockroachdb",
+			version:       v1alpha1.SpiceDBVersion{Name: "v1.0.1", Channel: "cockroachdb"},
+			expectedNames: []string{"v1.1.0"},
+		},
+	}
+
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			versions, err := tt.graph.AvailableVersions(tt.engine, tt.version)
+
+			switch tt.expectedErr {
+			case "":
+				require.Nil(t, err)
+			default:
+				require.NotNil(t, err)
+				require.Contains(t, err.Error(), tt.expectedErr)
+			}
+
+			if tt.expectedNames != nil {
+				names := make([]string, 0)
+				for _, v := range versions {
+					names = append(names, v.Name)
+				}
+				require.Equal(t, tt.expectedNames, names)
+			}
+		})
+	}
+}
+
+func TestComputeTarget(t *testing.T) {
+	table := []struct {
+		name              string
+		graph             *UpdateGraph
+		baseImage         string
+		image             string
+		version           string
+		channel           string
+		engine            string
+		currentVersion    *v1alpha1.SpiceDBVersion
+		rolling           bool
+		expectedBaseImage string
+		expectedTarget    *v1alpha1.SpiceDBVersion
+		expectedState     State
+		expectedErr       string
+	}{
+		{
+			name:        "missing images",
+			graph:       &UpdateGraph{},
+			expectedErr: "no base image",
+		},
+		{
+			name: "image with tag returns tag",
+			graph: &UpdateGraph{Channels: []Channel{{
+				Name:     "cockroachdb",
+				Metadata: map[string]string{"datastore": "cockroachdb"},
+				Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}},
+				Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
+			}}},
+			engine:            "cockroachdb",
+			currentVersion:    &v1alpha1.SpiceDBVersion{Name: "v1.0.0", Channel: "cockroachdb"},
+			image:             "ghcr.io/authzed/spicedb:tag",
+			expectedBaseImage: "ghcr.io/authzed/spicedb",
+			expectedState:     State{Tag: "tag"},
+		},
+		{
+			name: "image without tag acts as base image",
+			graph: &UpdateGraph{Channels: []Channel{{
+				Name:     "cockroachdb",
+				Metadata: map[string]string{"datastore": "cockroachdb"},
+				Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}},
+				Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
+			}}},
+			engine:            "cockroachdb",
+			currentVersion:    &v1alpha1.SpiceDBVersion{Name: "v1.0.0", Channel: "cockroachdb"},
+			image:             "ghcr.io/authzed/spicedb",
+			expectedBaseImage: "ghcr.io/authzed/spicedb",
+			expectedTarget:    &v1alpha1.SpiceDBVersion{Name: "v1.0.1", Channel: "cockroachdb"},
+			expectedState:     State{ID: "v1.0.1"},
+		},
+		{
+			name: "fallback to current version channel",
+			graph: &UpdateGraph{Channels: []Channel{{
+				Name:     "cockroachdb",
+				Metadata: map[string]string{"datastore": "cockroachdb"},
+				Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}},
+				Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
+			}}},
+			currentVersion:    &v1alpha1.SpiceDBVersion{Name: "v1.0.0", Channel: "cockroachdb"},
+			baseImage:         "ghcr.io/authzed/spicedb",
+			expectedBaseImage: "ghcr.io/authzed/spicedb",
+			expectedTarget:    &v1alpha1.SpiceDBVersion{Name: "v1.0.1", Channel: "cockroachdb"},
+			expectedState:     State{ID: "v1.0.1"},
+		},
+		{
+			name: "fallback to engine as channel",
+			graph: &UpdateGraph{Channels: []Channel{{
+				Name:     "cockroachdb",
+				Metadata: map[string]string{"datastore": "cockroachdb"},
+				Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}},
+				Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
+			}}},
+			engine:            "cockroachdb",
+			currentVersion:    &v1alpha1.SpiceDBVersion{Name: "v1.0.0"},
+			baseImage:         "ghcr.io/authzed/spicedb",
+			expectedBaseImage: "ghcr.io/authzed/spicedb",
+			expectedTarget:    &v1alpha1.SpiceDBVersion{Name: "v1.0.1", Channel: "cockroachdb"},
+			expectedState:     State{ID: "v1.0.1"},
+		},
+		{
+			name: "fail missing channel",
+			graph: &UpdateGraph{Channels: []Channel{{
+				Name:     "cockroachdb",
+				Metadata: map[string]string{"datastore": "cockroachdb"},
+				Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}},
+				Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
+			}}},
+			channel:           "missing",
+			currentVersion:    &v1alpha1.SpiceDBVersion{Name: "v1.0.0"},
+			baseImage:         "ghcr.io/authzed/spicedb",
+			expectedBaseImage: "ghcr.io/authzed/spicedb",
+			expectedErr:       "no channel found",
+		},
+		{
+			name: "rolling without current state fails",
+			graph: &UpdateGraph{Channels: []Channel{{
+				Name:     "cockroachdb",
+				Metadata: map[string]string{"datastore": "cockroachdb"},
+				Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}},
+				Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
+			}}},
+			channel:           "cockroachdb",
+			baseImage:         "ghcr.io/authzed/spicedb",
+			expectedBaseImage: "ghcr.io/authzed/spicedb",
+			rolling:           true,
+			expectedErr:       "no current state",
+		},
+		{
+			name: "rolling uses current version",
+			graph: &UpdateGraph{Channels: []Channel{{
+				Name:     "cockroachdb",
+				Metadata: map[string]string{"datastore": "cockroachdb"},
+				Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}},
+				Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
+			}}},
+			channel:           "cockroachdb",
+			baseImage:         "ghcr.io/authzed/spicedb",
+			expectedBaseImage: "ghcr.io/authzed/spicedb",
+			currentVersion:    &v1alpha1.SpiceDBVersion{Name: "v1.0.0", Channel: "cockroachdb"},
+			rolling:           true,
+			expectedTarget:    &v1alpha1.SpiceDBVersion{Name: "v1.0.0", Channel: "cockroachdb"},
+			expectedState:     State{ID: "v1.0.0"},
+		},
+		{
+			name: "head returns same version",
+			graph: &UpdateGraph{Channels: []Channel{{
+				Name:     "cockroachdb",
+				Metadata: map[string]string{"datastore": "cockroachdb"},
+				Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}},
+				Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
+			}}},
+			channel:           "cockroachdb",
+			baseImage:         "ghcr.io/authzed/spicedb",
+			expectedBaseImage: "ghcr.io/authzed/spicedb",
+			currentVersion:    &v1alpha1.SpiceDBVersion{Name: "v1.0.1", Channel: "cockroachdb"},
+			expectedTarget:    &v1alpha1.SpiceDBVersion{Name: "v1.0.1", Channel: "cockroachdb"},
+			expectedState:     State{ID: "v1.0.1"},
+		},
+		{
+			name: "no version returns head",
+			graph: &UpdateGraph{Channels: []Channel{{
+				Name:     "cockroachdb",
+				Metadata: map[string]string{"datastore": "cockroachdb"},
+				Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}},
+				Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
+			}}},
+			channel:           "cockroachdb",
+			baseImage:         "ghcr.io/authzed/spicedb",
+			expectedBaseImage: "ghcr.io/authzed/spicedb",
+			expectedTarget:    &v1alpha1.SpiceDBVersion{Name: "v1.0.1", Channel: "cockroachdb"},
+			expectedState:     State{ID: "v1.0.1"},
+		},
+	}
+
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			baseImage, target, state, err := tt.graph.ComputeTarget(
+				tt.baseImage,
+				tt.image,
+				tt.version,
+				tt.channel,
+				tt.engine,
+				tt.currentVersion,
+				tt.rolling,
+			)
+
+			switch tt.expectedErr {
+			case "":
+				require.Nil(t, err)
+			default:
+				require.NotNil(t, err)
+				require.Contains(t, err.Error(), tt.expectedErr)
+			}
+
+			require.Equal(t, tt.expectedBaseImage, baseImage)
+			require.Equal(t, tt.expectedState, state)
+			require.Equal(t, tt.expectedTarget, target)
+		})
+	}
+}

--- a/pkg/updates/memory.go
+++ b/pkg/updates/memory.go
@@ -123,8 +123,10 @@ func (m *MemorySource) validateAllNodesPathToHead() error {
 }
 
 func NewMemorySource(nodes []State, edges EdgeSet) (Source, error) {
-	if len(nodes) == 0 || len(edges) == 0 {
-		return nil, fmt.Errorf("no edges or no nodes")
+	if len(nodes) == 0 {
+		return nil, fmt.Errorf("missing nodes")
+	} else if len(edges) == 0 {
+		return nil, fmt.Errorf("missing edges")
 	}
 
 	nodeSet := make(map[string]int, len(nodes))

--- a/pkg/updates/memory_test.go
+++ b/pkg/updates/memory_test.go
@@ -285,7 +285,7 @@ func TestMemorySourceState(t *testing.T) {
 					"1": {"2"},
 				},
 			},
-			wantErr: "no edges or no nodes",
+			wantErr: "missing nodes",
 		},
 		{
 			name: "no edges",
@@ -294,7 +294,7 @@ func TestMemorySourceState(t *testing.T) {
 					{ID: "1"},
 				},
 			},
-			wantErr: "no edges or no nodes",
+			wantErr: "missing edges",
 		},
 		{
 			name: "edge not in list",


### PR DESCRIPTION
This PR refactors a bit of the logic being used to traverse the UpdateGraph into methods specifically on the update graph and adds tests for them.