### PR TITLE
pkg/config: Set correct Serice Account on pods

### DIFF
--- a/e2e/cluster_test.go
+++ b/e2e/cluster_test.go
@@ -214,6 +214,26 @@ var _ = Describe("SpiceDBClusters", func() {
 		}).Should(Succeed())
 	}
 
+	AssertServiceAccount := func(name string, annotations map[string]string, args func() (string, string)) {
+		namespace, owner := args()
+		ctx, cancel := context.WithCancel(context.Background())
+		DeferCleanup(cancel)
+
+		var serviceAccounts *corev1.ServiceAccountList
+		Eventually(func(g Gomega) {
+			var err error
+			serviceAccounts, err = kclient.CoreV1().ServiceAccounts(namespace).List(ctx, metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("%s=%s,%s=%s", metadata.ComponentLabelKey, metadata.ComponentServiceAccountLabel, metadata.OwnerLabelKey, owner),
+			})
+			g.Expect(err).To(Succeed())
+			g.Expect(len(serviceAccounts.Items)).To(Equal(1))
+			g.Expect(serviceAccounts.Items[0].GetName()).To(Equal(name))
+			for k, v := range annotations {
+				g.Expect(serviceAccounts.Items[0].GetAnnotations()).To(HaveKeyWithValue(k, v))
+			}
+		}).Should(Succeed())
+	}
+
 	AssertHealthySpiceDBCluster := func(image string, args func() (string, string), logMatcher types.GomegaMatcher) {
 		namespace, owner := args()
 		ctx, cancel := context.WithCancel(context.Background())
@@ -765,7 +785,7 @@ var _ = Describe("SpiceDBClusters", func() {
 				})
 			})
 
-			When("a valid SpiceDBCluster is created (with TLS)", Ordered, func() {
+			When("a valid SpiceDBCluster is created (with TLS and non-default Service Account)", Ordered, func() {
 				var spiceCluster *v1alpha1.SpiceDBCluster
 
 				BeforeAll(func() {
@@ -773,12 +793,14 @@ var _ = Describe("SpiceDBClusters", func() {
 					DeferCleanup(cancel)
 
 					config := map[string]any{
-						"datastoreEngine":              dsDef.datastoreEngine,
-						"envPrefix":                    spicedbEnvPrefix,
-						"cmd":                          spicedbCmd,
-						"image":                        "spicedb:dev",
-						"tlsSecretName":                "spicedb-grpc-tls",
-						"dispatchUpstreamCASecretName": "spicedb-grpc-tls",
+						"datastoreEngine":                dsDef.datastoreEngine,
+						"envPrefix":                      spicedbEnvPrefix,
+						"cmd":                            spicedbCmd,
+						"image":                          "spicedb:dev",
+						"tlsSecretName":                  "spicedb-grpc-tls",
+						"dispatchUpstreamCASecretName":   "spicedb-grpc-tls",
+						"serviceAccountName":             "spicedb-non-default",
+						"extraServiceAccountAnnotations": "authzed.com/e2e=true",
 					}
 					for k, v := range dsDef.passthroughConfig {
 						config[k] = v
@@ -850,6 +872,13 @@ var _ = Describe("SpiceDBClusters", func() {
 							func() (string, string) {
 								return testNamespace, spiceCluster.Name
 							}, Not(ContainSubstring("ERROR: kuberesolver")))
+					})
+
+					It("creates the service account", func() {
+						annotations := map[string]string{"authzed.com/e2e": "true"}
+						AssertServiceAccount("spicedb-non-default", annotations, func() (string, string) {
+							return testNamespace, spiceCluster.Name
+						})
 					})
 
 					When("the spicedb cluster is running", func() {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -933,7 +933,7 @@ func TestNewConfig(t *testing.T) {
 			wantPortCount: 4,
 		},
 		{
-			name: "set extra service account annotations as string",
+			name: "set extra service account with annotations as string",
 			args: args{
 				nn:  types.NamespacedName{Namespace: "test", Name: "test"},
 				uid: types.UID("1"),
@@ -955,6 +955,7 @@ func TestNewConfig(t *testing.T) {
 				rawConfig: json.RawMessage(`
 					{
 						"datastoreEngine": "cockroachdb",
+                        "serviceAccountName": "spicedb-non-default",
 						"extraServiceAccountAnnotations": "iam.gke.io/gcp-service-account=authzed-operator@account-12345.iam.gserviceaccount.com"
 					}
 				`),
@@ -979,15 +980,16 @@ func TestNewConfig(t *testing.T) {
 					},
 				},
 				SpiceConfig: SpiceConfig{
-					LogLevel:       "info",
-					SkipMigrations: false,
-					Name:           "test",
-					Namespace:      "test",
-					UID:            "1",
-					Replicas:       2,
-					PresharedKey:   "psk",
-					EnvPrefix:      "SPICEDB",
-					SpiceDBCmd:     "spicedb",
+					LogLevel:           "info",
+					SkipMigrations:     false,
+					Name:               "test",
+					Namespace:          "test",
+					UID:                "1",
+					Replicas:           2,
+					PresharedKey:       "psk",
+					EnvPrefix:          "SPICEDB",
+					SpiceDBCmd:         "spicedb",
+					ServiceAccountName: "spicedb-non-default",
 					ExtraServiceAccountAnnotations: map[string]string{
 						"iam.gke.io/gcp-service-account": "authzed-operator@account-12345.iam.gserviceaccount.com",
 					},
@@ -1008,7 +1010,7 @@ func TestNewConfig(t *testing.T) {
 			wantPortCount: 4,
 		},
 		{
-			name: "set extra service account annotations as map",
+			name: "set extra service account with annotations as map",
 			args: args{
 				nn:  types.NamespacedName{Namespace: "test", Name: "test"},
 				uid: types.UID("1"),
@@ -1030,6 +1032,7 @@ func TestNewConfig(t *testing.T) {
 				rawConfig: json.RawMessage(`
 					{
 						"datastoreEngine": "cockroachdb",
+                        "serviceAccountName": "spicedb-non-default",
 						"extraServiceAccountAnnotations": {
 							"iam.gke.io/gcp-service-account": "authzed-operator@account-12345.iam.gserviceaccount.com"
 						}
@@ -1056,15 +1059,16 @@ func TestNewConfig(t *testing.T) {
 					},
 				},
 				SpiceConfig: SpiceConfig{
-					LogLevel:       "info",
-					SkipMigrations: false,
-					Name:           "test",
-					Namespace:      "test",
-					UID:            "1",
-					Replicas:       2,
-					PresharedKey:   "psk",
-					EnvPrefix:      "SPICEDB",
-					SpiceDBCmd:     "spicedb",
+					LogLevel:           "info",
+					SkipMigrations:     false,
+					Name:               "test",
+					Namespace:          "test",
+					UID:                "1",
+					Replicas:           2,
+					PresharedKey:       "psk",
+					EnvPrefix:          "SPICEDB",
+					SpiceDBCmd:         "spicedb",
+					ServiceAccountName: "spicedb-non-default",
 					ExtraServiceAccountAnnotations: map[string]string{
 						"iam.gke.io/gcp-service-account": "authzed-operator@account-12345.iam.gserviceaccount.com",
 					},


### PR DESCRIPTION
We added support for specifying the name of the Service Account to be created in #122, but we didn't actually set it on the pods. This fixes that and adds tests.