### PR TITLE
include `bundle.yaml` file in the GH release

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -64,11 +64,10 @@ snapshot:
 changelog:
   use: "github-native"
   sort: "asc"
-includes:
-  - from_file:
-      path: "bundle.yaml"
 release:
   prerelease: "auto"
+  extra_files:
+    - glob: "bundle.yaml"
   footer: |
     ## Install with `kubectl`
     kubectl apply --server-side -f https://github.com/authzed/spicedb-operator/releases/download/v{{ .Version }}/bundle.yaml


### PR DESCRIPTION
The config was in the wrong section. 

There might be a couple more of these, since I can't easily test the GH release workflow locally