### PR TITLE
fix migration for postgres v1.14.0-v1.16.1

### DIFF
--- a/default-operator-config.yaml
+++ b/default-operator-config.yaml
@@ -148,22 +148,23 @@ channels:
     - v1.16.1
   metadata:
     datastore: postgres
+    default: "true"
   name: stable
   nodes:
   - id: v1.16.1
-    migration: drop-id-constraints
+    migration: drop-bigserial-ids
     tag: v1.16.1
   - id: v1.16.0
-    migration: drop-id-constraints
+    migration: drop-bigserial-ids
     tag: v1.16.0
   - id: v1.15.0
-    migration: drop-id-constraints
+    migration: drop-bigserial-ids
     tag: v1.15.0
   - id: v1.14.1
-    migration: drop-id-constraints
+    migration: drop-bigserial-ids
     tag: v1.14.1
   - id: v1.14.0
-    migration: drop-id-constraints
+    migration: drop-bigserial-ids
     tag: v1.14.0
   - id: v1.14.0-phase2
     migration: add-xid-constraints
@@ -408,6 +409,7 @@ channels:
     - v1.16.1
   metadata:
     datastore: cockroachdb
+    default: "true"
   name: stable
   nodes:
   - id: v1.16.1
@@ -555,6 +557,7 @@ channels:
     - v1.16.1
   metadata:
     datastore: mysql
+    default: "true"
   name: stable
   nodes:
   - id: v1.16.1
@@ -786,6 +789,7 @@ channels:
     - v1.16.1
   metadata:
     datastore: spanner
+    default: "true"
   name: stable
   nodes:
   - id: v1.16.1

--- a/tools/generate-update-graph/main.go
+++ b/tools/generate-update-graph/main.go
@@ -64,11 +64,11 @@ func main() {
 
 func postgresChannel() updates.Channel {
 	releases := []updates.State{
-		{ID: "v1.16.1", Tag: "v1.16.1", Migration: "drop-id-constraints"},
-		{ID: "v1.16.0", Tag: "v1.16.0", Migration: "drop-id-constraints"},
-		{ID: "v1.15.0", Tag: "v1.15.0", Migration: "drop-id-constraints"},
-		{ID: "v1.14.1", Tag: "v1.14.1", Migration: "drop-id-constraints"},
-		{ID: "v1.14.0", Tag: "v1.14.0", Migration: "drop-id-constraints"},
+		{ID: "v1.16.1", Tag: "v1.16.1", Migration: "drop-bigserial-ids"},
+		{ID: "v1.16.0", Tag: "v1.16.0", Migration: "drop-bigserial-ids"},
+		{ID: "v1.15.0", Tag: "v1.15.0", Migration: "drop-bigserial-ids"},
+		{ID: "v1.14.1", Tag: "v1.14.1", Migration: "drop-bigserial-ids"},
+		{ID: "v1.14.0", Tag: "v1.14.0", Migration: "drop-bigserial-ids"},
 		{ID: "v1.14.0-phase2", Tag: "v1.14.0", Migration: "add-xid-constraints", Phase: "write-both-read-new"},
 		{ID: "v1.14.0-phase1", Tag: "v1.14.0", Migration: "add-xid-columns", Phase: "write-both-read-old"},
 		{ID: "v1.13.0", Tag: "v1.13.0", Migration: "add-ns-config-id"},


### PR DESCRIPTION
Fixes #136 

The latest migration changed during development of the update graph feature, and was never updated.

In the future, a test suite will validate these graphs, for now, here's the status of a fresh postgres `SpiceDBCluster`:

```yaml
status:
  currentMigrationHash: n7ch99h687h697h56bh566h6ch688q
  image: ghcr.io/authzed/spicedb:v1.16.1
  migration: drop-bigserial-ids
  observedGeneration: 1
  targetMigrationHash: n7ch99h687h697h56bh566h6ch688q
  version:
    channel: stable
    name: v1.16.1
```