### PR TITLE
feat: add extraPodAnnotations on migrations jobs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -503,6 +503,8 @@ func (c *Config) MigrationJob(migrationHash string) *applybatchv1.JobApplyConfig
 		WithSpec(applybatchv1.JobSpec().WithTemplate(
 			applycorev1.PodTemplateSpec().WithLabels(
 				metadata.LabelsForComponent(c.Name, metadata.ComponentMigrationJobLabelValue),
+			).WithLabels(
+				c.ExtraPodLabels,
 			).WithAnnotations(
 				c.ExtraPodAnnotations,
 			).WithSpec(applycorev1.PodSpec().WithServiceAccountName(c.ServiceAccountName).

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -503,6 +503,8 @@ func (c *Config) MigrationJob(migrationHash string) *applybatchv1.JobApplyConfig
 		WithSpec(applybatchv1.JobSpec().WithTemplate(
 			applycorev1.PodTemplateSpec().WithLabels(
 				metadata.LabelsForComponent(c.Name, metadata.ComponentMigrationJobLabelValue),
+			).WithAnnotations(
+				c.ExtraPodAnnotations,
 			).WithSpec(applycorev1.PodSpec().WithServiceAccountName(c.ServiceAccountName).
 				WithContainers(
 					applycorev1.Container().


### PR DESCRIPTION
Istio, Banzai-vault and a lot of 3rd party kubernetes controllers and components requires specific annotations to set in order to work properly. While the SpiceDBCluster resource did have option to specify extra pod annotations before, it was not propagated to the migration jobs, effectively render the operator's managing migrations capability ineffective on clusters running controllers mentioned above.

This patch will simply add the specified extraPodAnnotations to the migration job's podTemplate, unlocking migration capabilities on such clusters.

Fixes: #146 