### PR TITLE
support merge_group event types in GHA

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: "ubuntu-latest"
     outputs:
       codechange: "${{ steps.filter.outputs.codechange }}"
+      graphchange: "${{ steps.graph-filter.outputs.graphchange }}"
     steps:
       - uses: "actions/checkout@v2"
       - uses: "dorny/paths-filter@v2"
@@ -32,6 +33,12 @@ jobs:
               - "pkg/**"
               - "e2e/**"
               - "internal/**"
+      - uses: "dorny/paths-filter@v2"
+        id: "graph-filter"
+        with:
+          filters: |
+            graphchange:
+              - "proposed-update-graph.yaml"
   build:
     needs: "paths-filter"
     if: |
@@ -92,11 +99,18 @@ jobs:
     runs-on: "ubuntu-latest-8-cores"
     steps:
       - uses: "actions/checkout@v3"
+        if: |
+          needs.paths-filter.outputs.graphchange == 'true'
         with:
           submodules: true
           token: "${{ secrets.AUTHZED_BOT_PAT }}"
           repository: "${{ github.event.pull_request.head.repo.full_name }}"
           ref: "${{ github.event.pull_request.head.ref }}"
+      - uses: "actions/checkout@v3"
+        if: |
+          needs.paths-filter.outputs.graphchange == 'false'
+        with:
+          submodules: true
       - uses: "authzed/actions/setup-go@main"
         with:
           go-version: "${{ env.GO_VERSION }}"
@@ -108,6 +122,8 @@ jobs:
           version: "latest"
           args: "test:e2e"
       - name: "Check if validated update graph has changed"
+        if: |
+          needs.paths-filter.outputs.graphchange == 'true'
         uses: "tj-actions/verify-changed-files@v13"
         id: "verify-changed-graph"
         with:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -4,6 +4,9 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - "main"
+  merge_group:
+    types:
+      - "checks_requested"
   pull_request:
     branches:
       - "*"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,6 +7,9 @@ on:  # yamllint disable-line rule:truthy
       - "main"
   pull_request:
     branches: ["*"]
+  merge_group:
+    types:
+      - "checks_requested"
 env:
   GO_VERSION: "~1.19"
 jobs:


### PR DESCRIPTION
I tried enabling the merge queue for this repo, but the required checks didn't run on queued PRs. 

It turns out there's a new type for merge queue events: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge-group

Once this merges I'll re-enable the merge queue and we can try again.