### PR TITLE
chore: Fix documentation for `ClusterStatus.CurrentVersion`

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ spec:
   config:
     datastoreEngine: cockroachdb
 status:
-  currentVersion:
+  version:
     name: v1.16.1
     channel: stable 
 ```
@@ -153,7 +153,7 @@ spec:
   config:
     datastoreEngine: cockroachdb
 status:
-  currentVersion:
+  version:
     name: v1.14.0
     channel: stable 
   availableVersions:


### PR DESCRIPTION
The documentation when giving examples of valid configs specifies the `ClusterStatus.CurrentVersion` as `currentVersion` when in reality is exposed as just `version` as defined [here](https://github.com/authzed/spicedb-operator/blob/6ebd7fd876dcde835ef4309808003edbc5dffb56/pkg/apis/authzed/v1alpha1/types.go#L151) in the code.

This updates the documentation for it to reduce confusion.