### PR TITLE
Use stable name for SpiceDB containers

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,8 @@ const (
 	// nolint:gosec // Creds in the naming causes a false positive here.
 	spannerCredsPath     = "/spanner-credentials"
 	spannerCredsFileName = "credentials.json"
+
+	ContainerNameSpiceDB = "spicedb"
 )
 
 type key[V comparable] struct {
@@ -709,7 +711,7 @@ func (c *Config) unpatchedDeployment(migrationHash, secretHash string) *applyapp
 				WithLabels(c.ExtraPodLabels).
 				WithAnnotations(c.ExtraPodAnnotations).
 				WithSpec(applycorev1.PodSpec().WithServiceAccountName(c.ServiceAccountName).WithContainers(
-					applycorev1.Container().WithName(name).WithImage(c.TargetSpiceDBImage).
+					applycorev1.Container().WithName(ContainerNameSpiceDB).WithImage(c.TargetSpiceDBImage).
 						WithCommand(c.SpiceConfig.SpiceDBCmd, "serve").
 						WithEnv(c.toEnvVarApplyConfiguration()...).
 						WithPorts(c.containerPorts()...).

--- a/pkg/controller/ensure_deployment_test.go
+++ b/pkg/controller/ensure_deployment_test.go
@@ -58,7 +58,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			migrationHash: "testtesttesttest",
 			secretHash:    "secret",
 			existingDeployments: []*appsv1.Deployment{{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				metadata.SpiceDBConfigKey: "n677h599h596hdch5fchbbh649h684q",
+				metadata.SpiceDBConfigKey: "nc5h5cdh9chb8h5dh68h5d8h87q",
 			}}}},
 			expectNext: nextKey,
 		},
@@ -67,7 +67,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			migrationHash: "testtesttesttest",
 			secretHash:    "secret",
 			existingDeployments: []*appsv1.Deployment{{}, {ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				metadata.SpiceDBConfigKey: "n677h599h596hdch5fchbbh649h684q",
+				metadata.SpiceDBConfigKey: "nc5h5cdh9chb8h5dh68h5d8h87q",
 			}}}},
 			expectDelete: true,
 			expectNext:   nextKey,
@@ -77,7 +77,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			migrationHash: "testtesttesttest",
 			secretHash:    "secret1",
 			existingDeployments: []*appsv1.Deployment{{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				metadata.SpiceDBConfigKey: "nb5hfh598h5h5d6h645h57fh64dq",
+				metadata.SpiceDBConfigKey: "nc5h5cdh9chb8h5dh68h5d8h87q",
 			}}}},
 			expectApply:        true,
 			expectRequeueAfter: true,
@@ -112,7 +112,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			}}}},
 			existingDeployments: []*appsv1.Deployment{{
 				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					metadata.SpiceDBConfigKey: "n5f7h557h56bhfdh5b8hf7h6fh687q",
+					metadata.SpiceDBConfigKey: "n5c7h5dfhb4hd7h5b6h689h577h576q",
 				}},
 				Status: appsv1.DeploymentStatus{
 					Replicas:          2,
@@ -145,7 +145,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			}}}},
 			existingDeployments: []*appsv1.Deployment{{
 				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					metadata.SpiceDBConfigKey: "n5f7h557h56bhfdh5b8hf7h6fh687q",
+					metadata.SpiceDBConfigKey: "n5c7h5dfhb4hd7h5b6h689h577h576q",
 				}},
 				Status: appsv1.DeploymentStatus{
 					Replicas:          2,


### PR DESCRIPTION
This uses a stable name of `spicedb` for SpiceDB containers in generated Deployment objects.  This makes applying patches to things inside the container definitions, like resources requests, much easier.