### PR TITLE
Set min connections low for tests

### DIFF
--- a/e2e/cluster_test.go
+++ b/e2e/cluster_test.go
@@ -234,12 +234,14 @@ var _ = Describe("SpiceDBClusters", func() {
 					}
 
 					config := map[string]any{
-						"skipReleaseCheck":  "true",
-						"telemetryEndpoint": "",
-						"datastoreEngine":   db.Engine,
-						"envPrefix":         spicedbEnvPrefix,
-						"image":             image,
-						"cmd":               spicedbCmd,
+						"skipReleaseCheck":              "true",
+						"telemetryEndpoint":             "",
+						"datastoreEngine":               db.Engine,
+						"datastoreConnpoolReadMinOpen":  1,
+						"datastoreConnpoolWriteMinOpen": 1,
+						"envPrefix":                     spicedbEnvPrefix,
+						"image":                         image,
+						"cmd":                           spicedbCmd,
 					}
 					for k, v := range db.ExtraConfig {
 						config[k] = v


### PR DESCRIPTION
This decreases the time it takes for a pod to become healthy and speeds up the tests.