### PR TITLE
Set SPICEDB_POD_NAME environment variable using the downward API

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -418,6 +418,8 @@ func (c *Config) toEnvVarApplyConfiguration() []*applycorev1.EnvVarApplyConfigur
 	// controller (dispatch address), has some direct effect on the cluster
 	// (tls), or lives in an external secret (preshared key).
 	envVars := []*applycorev1.EnvVarApplyConfiguration{
+		applycorev1.EnvVar().WithName(c.SpiceConfig.EnvPrefix + "_POD_NAME").WithValueFrom(
+			applycorev1.EnvVarSource().WithFieldRef(applycorev1.ObjectFieldSelector().WithFieldPath("metadata.name"))),
 		applycorev1.EnvVar().WithName(c.SpiceConfig.EnvPrefix + "_LOG_LEVEL").WithValue(c.LogLevel),
 		applycorev1.EnvVar().WithName(c.SpiceConfig.EnvPrefix + "_GRPC_PRESHARED_KEY").
 			WithValueFrom(applycorev1.EnvVarSource().WithSecretKeyRef(

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -150,6 +150,7 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
 				"SPICEDB_LOG_LEVEL=info",
 				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
 				"SPICEDB_DATASTORE_CONN_URI=datastore_uri",
@@ -227,6 +228,7 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
 				"SPICEDB_LOG_LEVEL=info",
 				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
 				"SPICEDB_DATASTORE_CONN_URI=datastore_uri",
@@ -302,6 +304,7 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
 				"SPICEDB_LOG_LEVEL=info",
 				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
 				"SPICEDB_DATASTORE_ENGINE=memory",
@@ -358,6 +361,7 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
 				"SPICEDB_LOG_LEVEL=info",
 				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
 				"SPICEDB_DATASTORE_CONN_URI=datastore_uri",
@@ -416,6 +420,7 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
 				"SPICEDB_LOG_LEVEL=info",
 				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
 				"SPICEDB_DATASTORE_CONN_URI=datastore_uri",
@@ -493,6 +498,7 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
 				"SPICEDB_LOG_LEVEL=info",
 				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
 				"SPICEDB_DATASTORE_CONN_URI=datastore_uri",
@@ -570,6 +576,7 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
 				"SPICEDB_LOG_LEVEL=info",
 				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
 				"SPICEDB_DATASTORE_CONN_URI=datastore_uri",
@@ -651,6 +658,7 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
 				"SPICEDB_LOG_LEVEL=info",
 				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
 				"SPICEDB_DATASTORE_CONN_URI=datastore_uri",
@@ -735,6 +743,7 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
 				"SPICEDB_LOG_LEVEL=info",
 				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
 				"SPICEDB_DATASTORE_CONN_URI=datastore_uri",
@@ -814,6 +823,7 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
 				"SPICEDB_LOG_LEVEL=info",
 				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
 				"SPICEDB_DATASTORE_CONN_URI=datastore_uri",
@@ -893,6 +903,7 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
 				"SPICEDB_LOG_LEVEL=info",
 				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
 				"SPICEDB_DATASTORE_CONN_URI=datastore_uri",
@@ -974,6 +985,7 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
 				"SPICEDB_LOG_LEVEL=info",
 				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
 				"SPICEDB_DATASTORE_CONN_URI=datastore_uri",
@@ -1058,6 +1070,7 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
 				"SPICEDB_LOG_LEVEL=info",
 				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
 				"SPICEDB_DATASTORE_CONN_URI=datastore_uri",
@@ -1139,6 +1152,7 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
 				"SPICEDB_LOG_LEVEL=info",
 				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
 				"SPICEDB_DATASTORE_CONN_URI=datastore_uri",
@@ -1222,6 +1236,7 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
 				"SPICEDB_LOG_LEVEL=info",
 				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
 				"SPICEDB_DATASTORE_CONN_URI=datastore_uri",
@@ -1240,7 +1255,7 @@ func TestNewConfig(t *testing.T) {
 						"logLevel": "debug",
 						"migrationLogLevel": "info",
 						"datastoreEngine": "cockroachdb",
-						"skipMigrations": "true"	
+						"skipMigrations": "true"
 					}
 				`)},
 				globalConfig: OperatorConfig{
@@ -1303,6 +1318,7 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
 				"SPICEDB_LOG_LEVEL=debug",
 				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
 				"SPICEDB_DATASTORE_CONN_URI=datastore_uri",
@@ -1383,6 +1399,7 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
 				"SPICEDB_LOG_LEVEL=debug",
 				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
 				"SPICEDB_DATASTORE_CONN_URI=datastore_uri",
@@ -1465,6 +1482,7 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
 				"SPICEDB_LOG_LEVEL=debug",
 				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
 				"SPICEDB_DATASTORE_CONN_URI=datastore_uri",
@@ -1553,6 +1571,7 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
 				"SPICEDB_LOG_LEVEL=debug",
 				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
 				"SPICEDB_DATASTORE_CONN_URI=datastore_uri",
@@ -1645,6 +1664,7 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
 				"SPICEDB_LOG_LEVEL=debug",
 				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
 				"SPICEDB_DATASTORE_CONN_URI=datastore_uri",
@@ -1725,6 +1745,7 @@ func TestNewConfig(t *testing.T) {
 				},
 			},
 			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
 				"SPICEDB_LOG_LEVEL=info",
 				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
 				"SPICEDB_DATASTORE_CONN_URI=datastore_uri",
@@ -1783,8 +1804,16 @@ func envVarFromStrings(envs []string) []*applycorev1.EnvVarApplyConfiguration {
 		if value != "" {
 			valuePtr = &value
 		}
-		// hack for the sake of simplifying test fixtures
-		// if it's lowercase key, we assume it's a secret
+
+		if _, ref, ok := strings.Cut(value, "FIELD_REF="); ok {
+			valueFrom = &applycorev1.EnvVarSourceApplyConfiguration{
+				FieldRef: &applycorev1.ObjectFieldSelectorApplyConfiguration{
+					FieldPath: &ref,
+				},
+			}
+			valuePtr = nil
+		}
+
 		if _, ok := secrets[name]; ok {
 			localname := ""
 			valueFrom = &applycorev1.EnvVarSourceApplyConfiguration{
@@ -1885,7 +1914,7 @@ func TestDeploymentContainerNameBackCompat(t *testing.T) {
 					{
 						"logLevel": "debug",
 						"datastoreEngine": "cockroachdb",
-						"skipMigrations": "true"	
+						"skipMigrations": "true"
 					}
 				`),
 					Patches: []v1alpha1.Patch{{
@@ -1895,7 +1924,7 @@ spec:
   template:
     spec:
       containers:
-      - name: test-spicedb 
+      - name: test-spicedb
         resources:
           requests:
             memory: "64Mi"
@@ -1953,6 +1982,7 @@ spec:
 							applycorev1.Container().WithName(ContainerNameSpiceDB).WithImage("image:v1").
 								WithCommand("spicedb", "serve").
 								WithEnv(
+									applycorev1.EnvVar().WithName("SPICEDB_POD_NAME").WithValueFrom(applycorev1.EnvVarSource().WithFieldRef(applycorev1.ObjectFieldSelector().WithFieldPath("metadata.name"))),
 									applycorev1.EnvVar().WithName("SPICEDB_LOG_LEVEL").WithValue("debug"),
 									applycorev1.EnvVar().WithName("SPICEDB_GRPC_PRESHARED_KEY").WithValueFrom(applycorev1.EnvVarSource().WithSecretKeyRef(applycorev1.SecretKeySelector().WithName("").WithKey("preshared_key"))),
 									applycorev1.EnvVar().WithName("SPICEDB_DATASTORE_CONN_URI").WithValueFrom(applycorev1.EnvVarSource().WithSecretKeyRef(applycorev1.SecretKeySelector().WithName("").WithKey("datastore_uri"))),
@@ -1995,7 +2025,7 @@ spec:
 					{
 						"logLevel": "debug",
 						"datastoreEngine": "cockroachdb",
-						"skipMigrations": "true"	
+						"skipMigrations": "true"
 					}
 				`),
 					Patches: []v1alpha1.Patch{{
@@ -2005,7 +2035,7 @@ spec:
   template:
     spec:
       containers:
-      - name: test-spicedb 
+      - name: test-spicedb
         resources:
           requests:
             memory: "64Mi"
@@ -2063,6 +2093,7 @@ spec:
 							applycorev1.Container().WithName(ContainerNameSpiceDB).WithImage("image:v1").
 								WithCommand("spicedb", "serve").
 								WithEnv(
+									applycorev1.EnvVar().WithName("SPICEDB_POD_NAME").WithValueFrom(applycorev1.EnvVarSource().WithFieldRef(applycorev1.ObjectFieldSelector().WithFieldPath("metadata.name"))),
 									applycorev1.EnvVar().WithName("SPICEDB_LOG_LEVEL").WithValue("debug"),
 									applycorev1.EnvVar().WithName("SPICEDB_GRPC_PRESHARED_KEY").WithValueFrom(applycorev1.EnvVarSource().WithSecretKeyRef(applycorev1.SecretKeySelector().WithName("").WithKey("preshared_key"))),
 									applycorev1.EnvVar().WithName("SPICEDB_DATASTORE_CONN_URI").WithValueFrom(applycorev1.EnvVarSource().WithSecretKeyRef(applycorev1.SecretKeySelector().WithName("").WithKey("datastore_uri"))),

--- a/pkg/controller/ensure_deployment_test.go
+++ b/pkg/controller/ensure_deployment_test.go
@@ -61,7 +61,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			migrationHash: "testtesttesttest",
 			secretHash:    "secret",
 			existingDeployments: []*appsv1.Deployment{{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				metadata.SpiceDBConfigKey: "nc5h5cdh9chb8h5dh68h5d8h87q",
+				metadata.SpiceDBConfigKey: "n549h6bh675h699h697h86h5cchdfq",
 			}}}},
 			expectNext: nextKey,
 		},
@@ -70,7 +70,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			migrationHash: "testtesttesttest",
 			secretHash:    "secret",
 			existingDeployments: []*appsv1.Deployment{{}, {ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				metadata.SpiceDBConfigKey: "nc5h5cdh9chb8h5dh68h5d8h87q",
+				metadata.SpiceDBConfigKey: "n549h6bh675h699h697h86h5cchdfq",
 			}}}},
 			expectDelete: true,
 			expectNext:   nextKey,
@@ -80,7 +80,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			migrationHash: "testtesttesttest",
 			secretHash:    "secret1",
 			existingDeployments: []*appsv1.Deployment{{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				metadata.SpiceDBConfigKey: "nc5h5cdh9chb8h5dh68h5d8h87q",
+				metadata.SpiceDBConfigKey: "n549h6bh675h699h697h86h5cchdfq",
 			}}}},
 			expectApply:        true,
 			expectRequeueAfter: true,
@@ -115,7 +115,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			}}}},
 			existingDeployments: []*appsv1.Deployment{{
 				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					metadata.SpiceDBConfigKey: "n5c7h5dfhb4hd7h5b6h689h577h576q",
+					metadata.SpiceDBConfigKey: "n87h696h5dch65dh56h699h5d6h5dbq",
 				}},
 				Status: appsv1.DeploymentStatus{
 					Replicas:          2,
@@ -148,7 +148,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			}}}},
 			existingDeployments: []*appsv1.Deployment{{
 				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					metadata.SpiceDBConfigKey: "n5c7h5dfhb4hd7h5b6h689h577h576q",
+					metadata.SpiceDBConfigKey: "n87h696h5dch65dh56h699h5d6h5dbq",
 				}},
 				Status: appsv1.DeploymentStatus{
 					Replicas:          2,
@@ -175,7 +175,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			}}}},
 			existingDeployments: []*appsv1.Deployment{{
 				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					metadata.SpiceDBConfigKey: "n5c7h5dfhb4hd7h5b6h689h577h576q",
+					metadata.SpiceDBConfigKey: "n87h696h5dch65dh56h699h5d6h5dbq",
 				}},
 				Status: appsv1.DeploymentStatus{
 					Replicas:          2,
@@ -221,7 +221,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			}}}},
 			existingDeployments: []*appsv1.Deployment{{
 				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					metadata.SpiceDBConfigKey: "n5c7h5dfhb4hd7h5b6h689h577h576q",
+					metadata.SpiceDBConfigKey: "n87h696h5dch65dh56h699h5d6h5dbq",
 				}},
 				Status: appsv1.DeploymentStatus{
 					Replicas:          2,
@@ -288,7 +288,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			}}}},
 			existingDeployments: []*appsv1.Deployment{{
 				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					metadata.SpiceDBConfigKey: "n5c7h5dfhb4hd7h5b6h689h577h576q",
+					metadata.SpiceDBConfigKey: "n87h696h5dch65dh56h699h5d6h5dbq",
 				}},
 				Status: appsv1.DeploymentStatus{
 					Replicas:          2,


### PR DESCRIPTION
Is this something we'd be interested in? Makes the pod name available in the `SPICEDB_POD_NAME` environment variable via the Kubernetes downward API.