### PR TITLE
Support and test switching channels

### DIFF
--- a/pkg/apis/authzed/v1alpha1/types.go
+++ b/pkg/apis/authzed/v1alpha1/types.go
@@ -186,6 +186,7 @@ var (
 	SpiceDBVersionAttributesMigration            SpiceDBVersionAttributes = "migration"
 	SpiceDBVersionAttributesIncompatibleDispatch SpiceDBVersionAttributes = "incompatibleDispatch"
 	SpiceDBVersionAttributesLatest               SpiceDBVersionAttributes = "latest"
+	SpiceDBVersionAttributesNotInChannel         SpiceDBVersionAttributes = "notInDesiredChannel"
 )
 
 type SpiceDBVersion struct {

--- a/pkg/updates/file_test.go
+++ b/pkg/updates/file_test.go
@@ -433,6 +433,165 @@ func TestComputeTarget(t *testing.T) {
 			},
 			expectedState: State{ID: "v1.0.0"},
 		},
+		{
+			name: "switching channel, current version is also in the target channel",
+			graph: &UpdateGraph{Channels: []Channel{
+				{
+					Name:     "rapid",
+					Metadata: map[string]string{"datastore": "cockroachdb"},
+					Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}, "v1.0.1": {"v1.0.2"}},
+					Nodes:    []State{{ID: "v1.0.2"}, {ID: "v1.0.1"}, {ID: "v1.0.0"}},
+				},
+				{
+					Name:     "regular",
+					Metadata: map[string]string{"datastore": "cockroachdb"},
+					Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}},
+					Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
+				},
+			}},
+			engine:    "cockroachdb",
+			channel:   "rapid",
+			version:   "v1.0.1",
+			baseImage: "ghcr.io/authzed/spicedb",
+			currentVersion: &v1alpha1.SpiceDBVersion{
+				Name:    "v1.0.1",
+				Channel: "regular",
+			},
+			expectedBaseImage: "ghcr.io/authzed/spicedb",
+			expectedTarget: &v1alpha1.SpiceDBVersion{
+				Name:    "v1.0.1",
+				Channel: "rapid",
+			},
+			expectedState: State{ID: "v1.0.1"},
+		},
+		{
+			name: "switching channel, version is in target channel, not setting explicit version",
+			graph: &UpdateGraph{Channels: []Channel{
+				{
+					Name:     "rapid",
+					Metadata: map[string]string{"datastore": "cockroachdb"},
+					Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}, "v1.0.1": {"v1.0.2"}},
+					Nodes:    []State{{ID: "v1.0.2"}, {ID: "v1.0.1"}, {ID: "v1.0.0"}},
+				},
+				{
+					Name:     "regular",
+					Metadata: map[string]string{"datastore": "cockroachdb"},
+					Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}},
+					Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
+				},
+			}},
+			engine:    "cockroachdb",
+			channel:   "rapid",
+			baseImage: "ghcr.io/authzed/spicedb",
+			currentVersion: &v1alpha1.SpiceDBVersion{
+				Name:    "v1.0.1",
+				Channel: "regular",
+			},
+			expectedBaseImage: "ghcr.io/authzed/spicedb",
+			expectedTarget: &v1alpha1.SpiceDBVersion{
+				Name:    "v1.0.2",
+				Channel: "rapid",
+			},
+			expectedState: State{ID: "v1.0.2"},
+		},
+		{
+			name: "switching channel and taking an update edge at the same time",
+			graph: &UpdateGraph{Channels: []Channel{
+				{
+					Name:     "rapid",
+					Metadata: map[string]string{"datastore": "cockroachdb"},
+					Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}, "v1.0.1": {"v1.0.2"}},
+					Nodes:    []State{{ID: "v1.0.2"}, {ID: "v1.0.1"}, {ID: "v1.0.0"}},
+				},
+				{
+					Name:     "regular",
+					Metadata: map[string]string{"datastore": "cockroachdb"},
+					Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}},
+					Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
+				},
+			}},
+			engine:    "cockroachdb",
+			channel:   "rapid",
+			version:   "v1.0.2",
+			baseImage: "ghcr.io/authzed/spicedb",
+			currentVersion: &v1alpha1.SpiceDBVersion{
+				Name:    "v1.0.1",
+				Channel: "regular",
+			},
+			expectedBaseImage: "ghcr.io/authzed/spicedb",
+			expectedTarget: &v1alpha1.SpiceDBVersion{
+				Name:    "v1.0.2",
+				Channel: "rapid",
+			},
+			expectedState: State{ID: "v1.0.2"},
+		},
+		{
+			name: "switching channel, current version is not in the target channel",
+			graph: &UpdateGraph{Channels: []Channel{
+				{
+					Name:     "rapid",
+					Metadata: map[string]string{"datastore": "cockroachdb"},
+					Edges:    EdgeSet{"v1.0.0": {"v1.0.2"}},
+					Nodes:    []State{{ID: "v1.0.2"}, {ID: "v1.0.0"}},
+				},
+				{
+					Name:     "regular",
+					Metadata: map[string]string{"datastore": "cockroachdb"},
+					Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}},
+					Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
+				},
+			}},
+			engine:    "cockroachdb",
+			channel:   "rapid",
+			version:   "v1.0.1",
+			baseImage: "ghcr.io/authzed/spicedb",
+			currentVersion: &v1alpha1.SpiceDBVersion{
+				Name:    "v1.0.1",
+				Channel: "regular",
+			},
+			expectedBaseImage: "ghcr.io/authzed/spicedb",
+			expectedTarget: &v1alpha1.SpiceDBVersion{
+				Name:    "v1.0.1",
+				Channel: "regular",
+				Attributes: []v1alpha1.SpiceDBVersionAttributes{
+					v1alpha1.SpiceDBVersionAttributesNotInChannel,
+				},
+			},
+			expectedState: State{ID: "v1.0.1"},
+		},
+		{
+			name: "switching channel, not setting explicit version, version not in target channel",
+			graph: &UpdateGraph{Channels: []Channel{
+				{
+					Name:     "rapid",
+					Metadata: map[string]string{"datastore": "cockroachdb"},
+					Edges:    EdgeSet{"v1.0.0": {"v1.0.2"}},
+					Nodes:    []State{{ID: "v1.0.2"}, {ID: "v1.0.0"}},
+				},
+				{
+					Name:     "regular",
+					Metadata: map[string]string{"datastore": "cockroachdb"},
+					Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}},
+					Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
+				},
+			}},
+			engine:    "cockroachdb",
+			channel:   "rapid",
+			baseImage: "ghcr.io/authzed/spicedb",
+			currentVersion: &v1alpha1.SpiceDBVersion{
+				Name:    "v1.0.1",
+				Channel: "regular",
+			},
+			expectedBaseImage: "ghcr.io/authzed/spicedb",
+			expectedTarget: &v1alpha1.SpiceDBVersion{
+				Name:    "v1.0.1",
+				Channel: "regular",
+				Attributes: []v1alpha1.SpiceDBVersionAttributes{
+					v1alpha1.SpiceDBVersionAttributesNotInChannel,
+				},
+			},
+			expectedState: State{ID: "v1.0.1"},
+		},
 	}
 
 	for _, tt := range table {


### PR DESCRIPTION
When multiple update channels are defined, the operator now has this behavior:

- If the currently running version exists in the new channel, the new channel takes over without any fanfare. If no version is asked for explicitly, updates will be walked in the new channel.
- If the currently running version doesn't exist in the new channel, the current version will be annotated with an attribute "not in desired channel". The operator will wait until the graph is updated and an edge is found in the desired channel.
