### PR TITLE
report errors even after an initial successful rollout

### DIFF
--- a/pkg/controller/ensure_deployment.go
+++ b/pkg/controller/ensure_deployment.go
@@ -99,7 +99,7 @@ func (m *DeploymentHandler) Handle(ctx context.Context) {
 	}
 
 	// check if any pods have errors
-	if cachedDeployment.Status.ReadyReplicas != config.Replicas {
+	if cachedDeployment.Status.UnavailableReplicas > 0 {
 		// sort pods by newest first
 		pods := m.getDeploymentPods(ctx)
 		sort.Slice(pods, func(i, j int) bool {

--- a/pkg/controller/ensure_deployment_test.go
+++ b/pkg/controller/ensure_deployment_test.go
@@ -178,10 +178,11 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 					metadata.SpiceDBConfigKey: "n87h696h5dch65dh56h699h5d6h5dbq",
 				}},
 				Status: appsv1.DeploymentStatus{
-					Replicas:          2,
-					UpdatedReplicas:   1,
-					AvailableReplicas: 1,
-					ReadyReplicas:     1,
+					Replicas:            2,
+					UpdatedReplicas:     1,
+					AvailableReplicas:   1,
+					ReadyReplicas:       1,
+					UnavailableReplicas: 1,
 				},
 			}},
 			pods: []*corev1.Pod{{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
@@ -224,10 +225,11 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 					metadata.SpiceDBConfigKey: "n87h696h5dch65dh56h699h5d6h5dbq",
 				}},
 				Status: appsv1.DeploymentStatus{
-					Replicas:          2,
-					UpdatedReplicas:   1,
-					AvailableReplicas: 1,
-					ReadyReplicas:     1,
+					Replicas:            2,
+					UpdatedReplicas:     1,
+					AvailableReplicas:   1,
+					ReadyReplicas:       1,
+					UnavailableReplicas: 1,
 				},
 			}},
 			pods: []*corev1.Pod{


### PR DESCRIPTION
the previous implementation just checked if there were the desired number of ready replicas, which would be the case if a good config had been previously rolled out and then changed.