### PR TITLE
remove migrating failed condition after a successful migration run

### DIFF
--- a/pkg/controller/ensure_deployment.go
+++ b/pkg/controller/ensure_deployment.go
@@ -30,7 +30,7 @@ func (m *DeploymentHandler) Handle(ctx context.Context) {
 	// TODO: unconditional status change can be a separate handler
 	currentStatus := CtxCluster.MustValue(ctx)
 	// remove migrating condition if present and set the current migration hash
-	if currentStatus.IsStatusConditionTrue(v1alpha1.ConditionTypeMigrating) ||
+	if currentStatus.FindStatusCondition(v1alpha1.ConditionTypeMigrating) != nil ||
 		currentStatus.Status.CurrentMigrationHash != currentStatus.Status.TargetMigrationHash {
 		currentStatus.RemoveStatusCondition(v1alpha1.ConditionTypeMigrating)
 		currentStatus.Status.CurrentMigrationHash = currentStatus.Status.TargetMigrationHash

--- a/pkg/controller/ensure_deployment_test.go
+++ b/pkg/controller/ensure_deployment_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -308,6 +309,29 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 					},
 				},
 			}}}}},
+			replicas:          2,
+			migrationHash:     "testtesttesttest",
+			secretHash:        "secret",
+			expectPatchStatus: true,
+			expectNext:        nextKey,
+			expectStatus:      &v1alpha1.SpiceDBCluster{Status: v1alpha1.ClusterStatus{Conditions: []metav1.Condition{}}},
+		},
+		{
+			name: "removes migrating failed status",
+			currentStatus: &v1alpha1.SpiceDBCluster{Status: v1alpha1.ClusterStatus{Conditions: []metav1.Condition{
+				v1alpha1.NewMigrationFailedCondition("postgres", "head", fmt.Errorf("err")),
+			}}},
+			existingDeployments: []*appsv1.Deployment{{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+					metadata.SpiceDBConfigKey: "n87h696h5dch65dh56h699h5d6h5dbq",
+				}},
+				Status: appsv1.DeploymentStatus{
+					Replicas:          2,
+					UpdatedReplicas:   2,
+					AvailableReplicas: 2,
+					ReadyReplicas:     2,
+				},
+			}},
 			replicas:          2,
 			migrationHash:     "testtesttesttest",
 			secretHash:        "secret",


### PR DESCRIPTION
If a migration job completely fails so that the cluster gets the MigrationFailed condition, it wouldn't be removed if the migrations were re-run and the cluster became healthy.