### PR TITLE
Build from distroless/base:nonroot

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,5 +1,5 @@
 # vim: syntax=dockerfile
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/base:nonroot
 COPY validated-update-graph.yaml /opt/operator/config.yaml
 COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.19 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
 COPY spicedb-operator /usr/local/bin/spicedb-operator


### PR DESCRIPTION
Switch from the default distroless image (which runs as root) to the distroless image (which runs as uid 65532)

Related to #237