### PR TITLE
add grouping and github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,22 @@ updates:
       interval: "monthly"
     labels:
       - "area/dependencies"
+    groups:
+      gomod-version:
+        patterns: ["*"]
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "monthly"
     labels:
       - "area/dependencies"
+    groups:
+      docker-version:
+        patterns: ["*"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions-version:
+        patterns: ["*"]


### PR DESCRIPTION
this add grouping to dependabot, so go mod updates come in a single PR
It also adds update configuration for github actions