### PR TITLE
Inject pod name into volume

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,7 @@ const (
 	telemetryTLSVolume = "telemetry-tls"
 	labelsVolume       = "podlabels"
 	annotationsVolume  = "podannotations"
+	podNameVolume      = "podname"
 
 	DefaultTLSKeyFile = "/tls/tls.key"
 	DefaultTLSCrtFile = "/tls/tls.crt"
@@ -576,6 +577,15 @@ func (c *Config) servicePorts() []*applycorev1.ServicePortApplyConfiguration {
 
 func (c *Config) jobVolumes() []*applycorev1.VolumeApplyConfiguration {
 	volumes := make([]*applycorev1.VolumeApplyConfiguration, 0)
+	volumes = append(volumes, applycorev1.Volume().WithName(podNameVolume).
+		WithDownwardAPI(applycorev1.DownwardAPIVolumeSource().WithItems(
+			applycorev1.DownwardAPIVolumeFile().
+				WithPath("name").
+				WithFieldRef(applycorev1.ObjectFieldSelector().
+					WithFieldPath("metadata.name"),
+				),
+		)))
+
 	if len(c.DatastoreTLSSecretName) > 0 {
 		volumes = append(volumes, applycorev1.Volume().WithName(dbTLSVolume).WithSecret(applycorev1.SecretVolumeSource().WithDefaultMode(420).WithSecretName(c.DatastoreTLSSecretName)))
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2083,6 +2083,14 @@ spec:
 								).
 								WithTerminationMessagePolicy(corev1.TerminationMessageFallbackToLogsOnError),
 						).WithVolumes(
+							applycorev1.Volume().WithName(podNameVolume).
+								WithDownwardAPI(applycorev1.DownwardAPIVolumeSource().WithItems(
+									applycorev1.DownwardAPIVolumeFile().
+										WithPath("name").
+										WithFieldRef(applycorev1.ObjectFieldSelector().
+											WithFieldPath("metadata.name"),
+										),
+								)),
 							applycorev1.Volume().WithName(labelsVolume).
 								WithDownwardAPI(applycorev1.DownwardAPIVolumeSource().WithItems(
 									applycorev1.DownwardAPIVolumeFile().
@@ -2215,6 +2223,14 @@ spec:
 								).
 								WithTerminationMessagePolicy(corev1.TerminationMessageFallbackToLogsOnError),
 						).WithVolumes(
+							applycorev1.Volume().WithName(podNameVolume).
+								WithDownwardAPI(applycorev1.DownwardAPIVolumeSource().WithItems(
+									applycorev1.DownwardAPIVolumeFile().
+										WithPath("name").
+										WithFieldRef(applycorev1.ObjectFieldSelector().
+											WithFieldPath("metadata.name"),
+										),
+								)),
 							applycorev1.Volume().WithName(labelsVolume).
 								WithDownwardAPI(applycorev1.DownwardAPIVolumeSource().WithItems(
 									applycorev1.DownwardAPIVolumeFile().

--- a/pkg/controller/ensure_deployment_test.go
+++ b/pkg/controller/ensure_deployment_test.go
@@ -62,7 +62,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			migrationHash: "testtesttesttest",
 			secretHash:    "secret",
 			existingDeployments: []*appsv1.Deployment{{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				metadata.SpiceDBConfigKey: "n59hb4h5f7h5b7h5dchddh79h67dq",
+				metadata.SpiceDBConfigKey: "nbh55ch546h5d8h57fhc9h557h684q",
 			}}}},
 			expectNext: nextKey,
 		},
@@ -71,7 +71,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			migrationHash: "testtesttesttest",
 			secretHash:    "secret",
 			existingDeployments: []*appsv1.Deployment{{}, {ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				metadata.SpiceDBConfigKey: "n59hb4h5f7h5b7h5dchddh79h67dq",
+				metadata.SpiceDBConfigKey: "nbh55ch546h5d8h57fhc9h557h684q",
 			}}}},
 			expectDelete: true,
 			expectNext:   nextKey,
@@ -81,7 +81,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			migrationHash: "testtesttesttest",
 			secretHash:    "secret1",
 			existingDeployments: []*appsv1.Deployment{{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				metadata.SpiceDBConfigKey: "n59hb4h5f7h5b7h5dchddh79h67dq",
+				metadata.SpiceDBConfigKey: "nbh55ch546h5d8h57fhc9h557h684q",
 			}}}},
 			expectApply:        true,
 			expectRequeueAfter: true,
@@ -116,7 +116,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			}}}},
 			existingDeployments: []*appsv1.Deployment{{
 				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					metadata.SpiceDBConfigKey: "n66bhc9h5c9h6fh8ch559h58bhb4q",
+					metadata.SpiceDBConfigKey: "n598h54fh54fh65dh579h5b8h68ch5ccq",
 				}},
 				Status: appsv1.DeploymentStatus{
 					Replicas:          2,
@@ -149,7 +149,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			}}}},
 			existingDeployments: []*appsv1.Deployment{{
 				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					metadata.SpiceDBConfigKey: "n66bhc9h5c9h6fh8ch559h58bhb4q",
+					metadata.SpiceDBConfigKey: "n598h54fh54fh65dh579h5b8h68ch5ccq",
 				}},
 				Status: appsv1.DeploymentStatus{
 					Replicas:          2,
@@ -176,7 +176,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			}}}},
 			existingDeployments: []*appsv1.Deployment{{
 				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					metadata.SpiceDBConfigKey: "n66bhc9h5c9h6fh8ch559h58bhb4q",
+					metadata.SpiceDBConfigKey: "n598h54fh54fh65dh579h5b8h68ch5ccq",
 				}},
 				Status: appsv1.DeploymentStatus{
 					Replicas:            2,
@@ -223,7 +223,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			}}}},
 			existingDeployments: []*appsv1.Deployment{{
 				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					metadata.SpiceDBConfigKey: "n66bhc9h5c9h6fh8ch559h58bhb4q",
+					metadata.SpiceDBConfigKey: "n598h54fh54fh65dh579h5b8h68ch5ccq",
 				}},
 				Status: appsv1.DeploymentStatus{
 					Replicas:            2,
@@ -291,7 +291,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			}}}},
 			existingDeployments: []*appsv1.Deployment{{
 				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					metadata.SpiceDBConfigKey: "n66bhc9h5c9h6fh8ch559h58bhb4q",
+					metadata.SpiceDBConfigKey: "n598h54fh54fh65dh579h5b8h68ch5ccq",
 				}},
 				Status: appsv1.DeploymentStatus{
 					Replicas:          2,
@@ -323,7 +323,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			}}},
 			existingDeployments: []*appsv1.Deployment{{
 				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					metadata.SpiceDBConfigKey: "n66bhc9h5c9h6fh8ch559h58bhb4q",
+					metadata.SpiceDBConfigKey: "n598h54fh54fh65dh579h5b8h68ch5ccq",
 				}},
 				Status: appsv1.DeploymentStatus{
 					Replicas:          2,


### PR DESCRIPTION
Adds the Kubernetes pod name to a file at `/etc/podmeta/name`. This aligns with the method we use to inject pod labels and annotations.