### PR TITLE
Increase default memory requests and limits

### DIFF
--- a/config/operator.yaml
+++ b/config/operator.yaml
@@ -62,10 +62,10 @@ spec:
           resources:
             limits:
               cpu: "250m"
-              memory: "128Mi"
+              memory: "160Mi"
             requests:
               cpu: "20m"
-              memory: "32Mi"
+              memory: "64Mi"
           securityContext:
             runAsUser: 65532
             runAsGroup: 65532


### PR DESCRIPTION
After https://github.com/authzed/spicedb-operator/pull/320, memory usage increased quite a bit. While still usually within the limits already set, this commit bumps the defaults a bit to provide similar headroom to the previous defaults.

https://github.com/authzed/spicedb-operator/issues/322 tracks finding the root cause (the openapi change or the kube dependency updates), after which we can lower these defaults down again.