### PR TITLE
release: updates for goreleaser v2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
         with:
           distribution: "goreleaser-pro"
           version: "latest"
-          args: "release --rm-dist"
+          args: "release --clean"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           GORELEASER_KEY: "${{ secrets.GORELEASER_KEY }}"

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -1,4 +1,5 @@
 ---
+version: 2
 builds:
   - id: "spicedb-operator"
     main: "./cmd/spicedb-operator"


### PR DESCRIPTION
- adds version to the goreleaser file
- changes deprecated `--rm-dist` to `--clean` (v2 fails instead of warning)