### PR TITLE
only run codeql on pull requests

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -66,6 +66,7 @@ jobs:
       - uses: "authzed/actions/markdown-lint@main"
 
   codeql:
+    if: "${{ github.event_name == 'pull_request' }}"
     name: "Analyze with CodeQL"
     runs-on: "ubuntu-latest-8-cores"
     permissions:


### PR DESCRIPTION
codeql doesn't support running on merge queue right now, so it always errors.