### PR TITLE
Add watch-namespaces to spicedb-operator cmd

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -152,7 +152,7 @@ func NewController(ctx context.Context, registry *typed.Registry, dclient dynami
 			DependentFactoryKey,
 			dclient,
 			0,
-			metav1.NamespaceAll,
+			ns,
 			func(options *metav1.ListOptions) {
 				options.LabelSelector = metadata.ManagedDependentSelector.String()
 			},
@@ -180,7 +180,8 @@ func NewController(ctx context.Context, registry *typed.Registry, dclient dynami
 				return nil, err
 			}
 		}
-	externalInformerFactories = append(externalInformerFactories, externalInformerFactory)
+		externalInformerFactories = append(externalInformerFactories, externalInformerFactory)
+	}
 
 	// start informers
 	for _, ownedInformerFactory := range ownedInformerFactories {


### PR DESCRIPTION
https://github.com/authzed/spicedb-operator/issues/291#issuecomment-2209427392

Introduce `--watch-namespaces` argument to the spicedb-operator cmd, which accepts a comma-separated list of namespaces to watch. Update the controller to set up informers for each namespace. If the argument is not set, the operator continues to work at a cluster-wide level using `NamespaceAll`.
