### PR TITLE
Fix golangci-lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,15 +1,5 @@
 ---
-run:
-  timeout: "5m"
-output:
-  sort-results: true
-linters-settings:
-  goimports:
-    local-prefixes: "github.com/authzed/spicedb-operator"
-  stylecheck:
-    dot-import-whitelist:
-      - "github.com/onsi/ginkgo/v2"
-      - "github.com/onsi/gomega"
+version: "2"
 linters:
   enable:
     - "bidichk"
@@ -17,11 +7,8 @@ linters:
     - "errcheck"
     - "errname"
     - "errorlint"
-    - "gofumpt"
-    - "goimports"
     - "goprintffuncname"
     - "gosec"
-    - "gosimple"
     - "govet"
     - "importas"
     - "ineffassign"
@@ -32,10 +19,38 @@ linters:
     - "revive"
     - "rowserrcheck"
     - "staticcheck"
-    - "stylecheck"
-    - "tenv"
-    - "typecheck"
     - "unconvert"
     - "unused"
+    - "usetesting"
     - "wastedassign"
     - "whitespace"
+  settings:
+    staticcheck:
+      dot-import-whitelist:
+        - "github.com/onsi/ginkgo/v2"
+        - "github.com/onsi/gomega"
+  exclusions:
+    generated: "lax"
+    presets:
+      - "comments"
+      - "common-false-positives"
+      - "legacy"
+      - "std-error-handling"
+    paths:
+      - "third_party$"
+      - "builtin$"
+      - "examples$"
+formatters:
+  enable:
+    - "gofumpt"
+    - "goimports"
+  settings:
+    goimports:
+      local-prefixes:
+        - "github.com/authzed/spicedb-operator"
+  exclusions:
+    generated: "lax"
+    paths:
+      - "third_party$"
+      - "builtin$"
+      - "examples$"

--- a/pkg/apis/authzed/v1alpha1/types.go
+++ b/pkg/apis/authzed/v1alpha1/types.go
@@ -41,14 +41,14 @@ type SpiceDBCluster struct {
 }
 
 func (c *SpiceDBCluster) WithAnnotations(entries map[string]string) *SpiceDBCluster {
-	annotations := c.ObjectMeta.GetAnnotations()
+	annotations := c.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
 	for k, v := range entries {
 		annotations[k] = v
 	}
-	c.ObjectMeta.SetAnnotations(annotations)
+	c.SetAnnotations(annotations)
 	return c
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -861,7 +861,7 @@ func fixDeploymentPatches(name string, in []v1alpha1.Patch) []v1alpha1.Patch {
 	patches = append(patches, in...)
 	for i, p := range patches {
 		// not a deployment patch
-		if !(p.Kind == "Deployment" || p.Kind == wildcard) {
+		if p.Kind != "Deployment" && p.Kind != wildcard {
 			continue
 		}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1966,7 +1966,7 @@ func TestGraphDiffSanity(t *testing.T) {
 	proposedGraph := GetConfig("../../proposed-update-graph.yaml")
 	validatedGraph := GetConfig("../../config/update-graph.yaml")
 	require.NotPanics(t, func() {
-		_ = proposedGraph.UpdateGraph.Difference(&validatedGraph.UpdateGraph)
+		_ = proposedGraph.Difference(&validatedGraph.UpdateGraph)
 	})
 }
 

--- a/pkg/controller/validate_config.go
+++ b/pkg/controller/validate_config.go
@@ -71,7 +71,7 @@ func (c *ValidateConfigHandler) Handle(ctx context.Context) {
 		Conditions:           *cluster.GetStatusConditions(),
 	}
 	if version := validatedConfig.SpiceDBVersion; version != nil {
-		computedStatus.AvailableVersions, err = operatorConfig.UpdateGraph.AvailableVersions(validatedConfig.DatastoreEngine, *version)
+		computedStatus.AvailableVersions, err = operatorConfig.AvailableVersions(validatedConfig.DatastoreEngine, *version)
 		if err != nil {
 			QueueOps.RequeueErr(ctx, err)
 			return


### PR DESCRIPTION
## Description
This repo hadn't been migrated to v2 yet. This fixes that.

## Changes
* Run `golangci-lint migrate`
## Testing
Review. See that tests pass.