### PR TITLE
Generate a PDB that protects SpiceDB replicas

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -75,6 +75,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/e2e/cluster_test.go
+++ b/e2e/cluster_test.go
@@ -61,6 +61,7 @@ var _ = Describe("SpiceDBClusters", func() {
 
 		AssertMigrationJobCleanup      func(owner string)
 		AssertServiceAccount           func(name string, annotations map[string]string, owner string)
+		AssertPDB                      func(name, owner string)
 		AssertHealthySpiceDBCluster    func(image, owner string, logMatcher types.GomegaMatcher)
 		AssertDependentResourceCleanup func(owner, secretName string)
 		AssertMigrationsCompleted      func(image, migration, phase, name, datastoreEngine string)
@@ -125,6 +126,7 @@ var _ = Describe("SpiceDBClusters", func() {
 
 		AssertMigrationJobCleanup = AssertMigrationJobCleanupFunc(ctx, testNamespace, kclient)
 		AssertServiceAccount = AssertServiceAccountFunc(ctx, testNamespace, kclient)
+		AssertPDB = AssertPDBFunc(ctx, testNamespace, kclient)
 		AssertHealthySpiceDBCluster = AssertHealthySpiceDBClusterFunc(ctx, testNamespace, kclient)
 		AssertDependentResourceCleanup = AssertDependentResourceCleanupFunc(ctx, testNamespace, kclient)
 		AssertMigrationsCompleted = AssertMigrationsCompletedFunc(ctx, testNamespace, kclient, client)
@@ -322,6 +324,7 @@ var _ = Describe("SpiceDBClusters", func() {
 
 						By("creating the serviceaccount")
 						AssertServiceAccount("spicedb-non-default", map[string]string{"authzed.com/e2e": "true"}, cluster.Name)
+						AssertPDB(cluster.Name+"-spicedb", cluster.Name)
 					})
 				})
 			})

--- a/pkg/metadata/keys.go
+++ b/pkg/metadata/keys.go
@@ -28,6 +28,7 @@ const (
 	ComponentRoleLabel              = "spicedb-role"
 	ComponentServiceLabel           = "spicedb-service"
 	ComponentRoleBindingLabel       = "spicedb-rolebinding"
+	ComponentPDBLabel               = "spicedb-pdb"
 	SpiceDBMigrationRequirementsKey = "authzed.com/spicedb-migration"
 	SpiceDBTargetMigrationKey       = "authzed.com/spicedb-target-migration"
 	SpiceDBSecretRequirementsKey    = "authzed.com/spicedb-secret" // nolint: gosec


### PR DESCRIPTION
This prevents infrastructure changes from disrupting more than 1 pod in a SpiceDB cluster at a time.

Fixes CTL-874