### PR TITLE
allow overriding the base-image defined in the update graph

### DIFF
--- a/config/crds/authzed.com_spicedbclusters.yaml
+++ b/config/crds/authzed.com_spicedbclusters.yaml
@@ -71,6 +71,12 @@ spec:
           spec:
             description: ClusterSpec holds the desired state of the cluster.
             properties:
+              baseImage:
+                description: |-
+                  BaseImage specifies the base container image to use for SpiceDB.
+                  If not specified, will fall back to the operator's --base-image flag,
+                  then to the imageName defined in the update graph.
+                type: string
               channel:
                 description: |-
                   Channel is a defined series of updates that operator should follow.

--- a/pkg/apis/authzed/v1alpha1/types.go
+++ b/pkg/apis/authzed/v1alpha1/types.go
@@ -98,6 +98,12 @@ type ClusterSpec struct {
 	// in the list take precedence over earlier ones.
 	// +optional
 	Patches []Patch `json:"patches,omitempty"`
+
+	// BaseImage specifies the base container image to use for SpiceDB.
+	// If not specified, will fall back to the operator's --base-image flag,
+	// then to the imageName defined in the update graph.
+	// +optional
+	BaseImage string `json:"baseImage,omitempty"`
 }
 
 // Patch represents a single change to apply to generated manifests

--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -43,6 +43,7 @@ type Options struct {
 	BootstrapCRDs         bool
 	BootstrapSpicedbsPath string
 	OperatorConfigPath    string
+	BaseImage             string
 
 	MetricNamespace string
 
@@ -87,6 +88,7 @@ func NewCmdRun(o *Options) *cobra.Command {
 	globalFlags := namedFlagSets.FlagSet("global")
 	globalflag.AddGlobalFlags(globalFlags, cmd.Name())
 	globalFlags.StringVar(&o.OperatorConfigPath, "config", "", "set a path to the operator's config file (configure registries, image tags, etc)")
+	globalFlags.StringVar(&o.BaseImage, "base-image", "", "default base image for SpiceDB containers")
 
 	for _, f := range namedFlagSets.FlagSets {
 		cmd.Flags().AddFlagSet(f)
@@ -153,7 +155,7 @@ func (o *Options) Run(ctx context.Context, f cmdutil.Factory) error {
 		controllers = append(controllers, staticSpiceDBController)
 	}
 
-	ctrl, err := controller.NewController(ctx, registry, dclient, kclient, resources, o.OperatorConfigPath, broadcaster, o.WatchNamespaces)
+	ctrl, err := controller.NewController(ctx, registry, dclient, kclient, resources, o.OperatorConfigPath, o.BaseImage, broadcaster, o.WatchNamespaces)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -223,7 +223,7 @@ func NewConfig(cluster *v1alpha1.SpiceDBCluster, globalConfig *OperatorConfig, s
 	// unless the current config is equal to the input.
 	image := imageKey.pop(config)
 
-	baseImage, targetSpiceDBVersion, state, err := globalConfig.ComputeTarget(globalConfig.ImageName, image, cluster.Spec.Version, cluster.Spec.Channel, datastoreEngine, cluster.Status.CurrentVersion, cluster.RolloutInProgress())
+	baseImage, targetSpiceDBVersion, state, err := globalConfig.ComputeTarget(globalConfig.ImageName, cluster.Spec.BaseImage, image, cluster.Spec.Version, cluster.Spec.Channel, datastoreEngine, cluster.Status.CurrentVersion, cluster.RolloutInProgress())
 	if err != nil {
 		errs = append(errs, err)
 	}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -135,7 +135,7 @@ func TestControllerNamespacing(t *testing.T) {
 			broadcaster := record.NewBroadcaster()
 			dclient := fake.NewSimpleDynamicClient(scheme.Scheme)
 			kclient := kfake.NewSimpleClientset()
-			c, err := NewController(ctx, registry, dclient, kclient, nil, "", broadcaster, tt.watchedNamespaces)
+			c, err := NewController(ctx, registry, dclient, kclient, nil, "", "", broadcaster, tt.watchedNamespaces)
 			require.NoError(t, err)
 			queue := newKeyRecordingQueue(workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[any]()))
 			c.Queue = queue

--- a/pkg/crds/authzed.com_spicedbclusters.yaml
+++ b/pkg/crds/authzed.com_spicedbclusters.yaml
@@ -71,6 +71,12 @@ spec:
           spec:
             description: ClusterSpec holds the desired state of the cluster.
             properties:
+              baseImage:
+                description: |-
+                  BaseImage specifies the base container image to use for SpiceDB.
+                  If not specified, will fall back to the operator's --base-image flag,
+                  then to the imageName defined in the update graph.
+                type: string
               channel:
                 description: |-
                   Channel is a defined series of updates that operator should follow.

--- a/pkg/updates/file_test.go
+++ b/pkg/updates/file_test.go
@@ -175,7 +175,8 @@ func TestComputeTarget(t *testing.T) {
 	table := []struct {
 		name              string
 		graph             *UpdateGraph
-		baseImage         string
+		operatorImageName string
+		clusterBaseImage  string
 		image             string
 		version           string
 		channel           string
@@ -231,7 +232,7 @@ func TestComputeTarget(t *testing.T) {
 			}}},
 			engine:            "cockroachdb",
 			currentVersion:    &v1alpha1.SpiceDBVersion{Name: "v1.0.0", Channel: "cockroachdb"},
-			baseImage:         "ghcr.io/authzed/spicedb",
+			operatorImageName: "ghcr.io/authzed/spicedb",
 			expectedBaseImage: "ghcr.io/authzed/spicedb",
 			expectedTarget:    &v1alpha1.SpiceDBVersion{Name: "v1.0.1", Channel: "cockroachdb"},
 			expectedState:     State{ID: "v1.0.1"},
@@ -246,7 +247,7 @@ func TestComputeTarget(t *testing.T) {
 			}}},
 			engine:            "cockroachdb",
 			currentVersion:    &v1alpha1.SpiceDBVersion{Name: "v1.0.0", Channel: "cockroachdb"},
-			baseImage:         "ghcr.io/authzed/spicedb",
+			operatorImageName: "ghcr.io/authzed/spicedb",
 			expectedBaseImage: "ghcr.io/authzed/spicedb",
 			expectedTarget:    &v1alpha1.SpiceDBVersion{Name: "v1.0.1", Channel: "cockroachdb"},
 			expectedState:     State{ID: "v1.0.1"},
@@ -261,7 +262,7 @@ func TestComputeTarget(t *testing.T) {
 			}}},
 			channel:           "missing",
 			currentVersion:    &v1alpha1.SpiceDBVersion{Name: "v1.0.0"},
-			baseImage:         "ghcr.io/authzed/spicedb",
+			operatorImageName: "ghcr.io/authzed/spicedb",
 			expectedBaseImage: "ghcr.io/authzed/spicedb",
 			expectedErr:       "no channel",
 		},
@@ -275,7 +276,7 @@ func TestComputeTarget(t *testing.T) {
 			}}},
 			engine:            "cockroachdb",
 			channel:           "cockroachdb",
-			baseImage:         "ghcr.io/authzed/spicedb",
+			operatorImageName: "ghcr.io/authzed/spicedb",
 			expectedBaseImage: "ghcr.io/authzed/spicedb",
 			rolling:           true,
 			expectedErr:       "no current state",
@@ -290,7 +291,7 @@ func TestComputeTarget(t *testing.T) {
 			}}},
 			engine:            "cockroachdb",
 			channel:           "cockroachdb",
-			baseImage:         "ghcr.io/authzed/spicedb",
+			operatorImageName: "ghcr.io/authzed/spicedb",
 			expectedBaseImage: "ghcr.io/authzed/spicedb",
 			currentVersion:    &v1alpha1.SpiceDBVersion{Name: "v1.0.0", Channel: "cockroachdb"},
 			rolling:           true,
@@ -308,7 +309,7 @@ func TestComputeTarget(t *testing.T) {
 			engine:            "cockroachdb",
 			channel:           "cockroachdb",
 			version:           "v1.0.1",
-			baseImage:         "ghcr.io/authzed/spicedb",
+			operatorImageName: "ghcr.io/authzed/spicedb",
 			expectedBaseImage: "ghcr.io/authzed/spicedb",
 			currentVersion:    &v1alpha1.SpiceDBVersion{Name: "v1.0.0", Channel: "cockroachdb"},
 			expectedTarget: &v1alpha1.SpiceDBVersion{
@@ -329,7 +330,7 @@ func TestComputeTarget(t *testing.T) {
 			engine:            "cockroachdb",
 			channel:           "cockroachdb",
 			version:           "v1.0.1",
-			baseImage:         "ghcr.io/authzed/spicedb",
+			operatorImageName: "ghcr.io/authzed/spicedb",
 			expectedBaseImage: "ghcr.io/authzed/spicedb",
 			currentVersion:    &v1alpha1.SpiceDBVersion{Name: "v1.0.0", Channel: "cockroachdb"},
 			expectedTarget: &v1alpha1.SpiceDBVersion{
@@ -349,7 +350,7 @@ func TestComputeTarget(t *testing.T) {
 			engine:            "cockroachdb",
 			channel:           "cockroachdb",
 			version:           "v1.0.0",
-			baseImage:         "ghcr.io/authzed/spicedb",
+			operatorImageName: "ghcr.io/authzed/spicedb",
 			expectedBaseImage: "ghcr.io/authzed/spicedb",
 			expectedTarget: &v1alpha1.SpiceDBVersion{
 				Name:       "v1.0.0",
@@ -369,7 +370,7 @@ func TestComputeTarget(t *testing.T) {
 			engine:            "cockroachdb",
 			channel:           "cockroachdb",
 			version:           "v1.0.0",
-			baseImage:         "ghcr.io/authzed/spicedb",
+			operatorImageName: "ghcr.io/authzed/spicedb",
 			expectedBaseImage: "ghcr.io/authzed/spicedb",
 			expectedTarget: &v1alpha1.SpiceDBVersion{
 				Name:       "v1.0.0",
@@ -388,7 +389,7 @@ func TestComputeTarget(t *testing.T) {
 			}}},
 			engine:            "cockroachdb",
 			channel:           "cockroachdb",
-			baseImage:         "ghcr.io/authzed/spicedb",
+			operatorImageName: "ghcr.io/authzed/spicedb",
 			expectedBaseImage: "ghcr.io/authzed/spicedb",
 			currentVersion:    &v1alpha1.SpiceDBVersion{Name: "v1.0.1", Channel: "cockroachdb"},
 			expectedTarget:    &v1alpha1.SpiceDBVersion{Name: "v1.0.1", Channel: "cockroachdb"},
@@ -404,7 +405,7 @@ func TestComputeTarget(t *testing.T) {
 			}}},
 			engine:            "cockroachdb",
 			channel:           "cockroachdb",
-			baseImage:         "ghcr.io/authzed/spicedb",
+			operatorImageName: "ghcr.io/authzed/spicedb",
 			expectedBaseImage: "ghcr.io/authzed/spicedb",
 			expectedTarget: &v1alpha1.SpiceDBVersion{
 				Name:       "v1.0.1",
@@ -424,7 +425,7 @@ func TestComputeTarget(t *testing.T) {
 			engine:            "cockroachdb",
 			channel:           "cockroachdb",
 			version:           "v1.0.0",
-			baseImage:         "ghcr.io/authzed/spicedb",
+			operatorImageName: "ghcr.io/authzed/spicedb",
 			expectedBaseImage: "ghcr.io/authzed/spicedb",
 			expectedTarget: &v1alpha1.SpiceDBVersion{
 				Name:       "v1.0.0",
@@ -449,10 +450,10 @@ func TestComputeTarget(t *testing.T) {
 					Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
 				},
 			}},
-			engine:    "cockroachdb",
-			channel:   "rapid",
-			version:   "v1.0.1",
-			baseImage: "ghcr.io/authzed/spicedb",
+			engine:            "cockroachdb",
+			channel:           "rapid",
+			version:           "v1.0.1",
+			operatorImageName: "ghcr.io/authzed/spicedb",
 			currentVersion: &v1alpha1.SpiceDBVersion{
 				Name:    "v1.0.1",
 				Channel: "regular",
@@ -480,9 +481,9 @@ func TestComputeTarget(t *testing.T) {
 					Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
 				},
 			}},
-			engine:    "cockroachdb",
-			channel:   "rapid",
-			baseImage: "ghcr.io/authzed/spicedb",
+			engine:            "cockroachdb",
+			channel:           "rapid",
+			operatorImageName: "ghcr.io/authzed/spicedb",
 			currentVersion: &v1alpha1.SpiceDBVersion{
 				Name:    "v1.0.1",
 				Channel: "regular",
@@ -510,10 +511,10 @@ func TestComputeTarget(t *testing.T) {
 					Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
 				},
 			}},
-			engine:    "cockroachdb",
-			channel:   "rapid",
-			version:   "v1.0.2",
-			baseImage: "ghcr.io/authzed/spicedb",
+			engine:            "cockroachdb",
+			channel:           "rapid",
+			version:           "v1.0.2",
+			operatorImageName: "ghcr.io/authzed/spicedb",
 			currentVersion: &v1alpha1.SpiceDBVersion{
 				Name:    "v1.0.1",
 				Channel: "regular",
@@ -541,10 +542,10 @@ func TestComputeTarget(t *testing.T) {
 					Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
 				},
 			}},
-			engine:    "cockroachdb",
-			channel:   "rapid",
-			version:   "v1.0.1",
-			baseImage: "ghcr.io/authzed/spicedb",
+			engine:            "cockroachdb",
+			channel:           "rapid",
+			version:           "v1.0.1",
+			operatorImageName: "ghcr.io/authzed/spicedb",
 			currentVersion: &v1alpha1.SpiceDBVersion{
 				Name:    "v1.0.1",
 				Channel: "regular",
@@ -575,9 +576,9 @@ func TestComputeTarget(t *testing.T) {
 					Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
 				},
 			}},
-			engine:    "cockroachdb",
-			channel:   "rapid",
-			baseImage: "ghcr.io/authzed/spicedb",
+			engine:            "cockroachdb",
+			channel:           "rapid",
+			operatorImageName: "ghcr.io/authzed/spicedb",
 			currentVersion: &v1alpha1.SpiceDBVersion{
 				Name:    "v1.0.1",
 				Channel: "regular",
@@ -592,12 +593,52 @@ func TestComputeTarget(t *testing.T) {
 			},
 			expectedState: State{ID: "v1.0.1"},
 		},
+		{
+			name: "cluster base image takes precedence over operator config",
+			graph: &UpdateGraph{Channels: []Channel{{
+				Name:     "cockroachdb",
+				Metadata: map[string]string{"datastore": "cockroachdb"},
+				Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}},
+				Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
+			}}},
+			engine:            "cockroachdb",
+			channel:           "cockroachdb",
+			currentVersion:    &v1alpha1.SpiceDBVersion{Name: "v1.0.1", Channel: "cockroachdb"},
+			operatorImageName: "registry.example.com/authzed/spicedb",
+			clusterBaseImage:  "public.ecr.aws/authzed/spicedb",
+			expectedBaseImage: "public.ecr.aws/authzed/spicedb",
+			expectedTarget: &v1alpha1.SpiceDBVersion{
+				Name:    "v1.0.1",
+				Channel: "cockroachdb",
+			},
+			expectedState: State{ID: "v1.0.1"},
+		},
+		{
+			name: "operator image used when cluster base image not specified",
+			graph: &UpdateGraph{Channels: []Channel{{
+				Name:     "cockroachdb",
+				Metadata: map[string]string{"datastore": "cockroachdb"},
+				Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}},
+				Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
+			}}},
+			engine:            "cockroachdb",
+			channel:           "cockroachdb",
+			currentVersion:    &v1alpha1.SpiceDBVersion{Name: "v1.0.1", Channel: "cockroachdb"},
+			operatorImageName: "registry.example.com/authzed/spicedb",
+			expectedBaseImage: "registry.example.com/authzed/spicedb",
+			expectedTarget: &v1alpha1.SpiceDBVersion{
+				Name:    "v1.0.1",
+				Channel: "cockroachdb",
+			},
+			expectedState: State{ID: "v1.0.1"},
+		},
 	}
 
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
 			baseImage, target, state, err := tt.graph.ComputeTarget(
-				tt.baseImage,
+				tt.operatorImageName,
+				tt.clusterBaseImage,
 				tt.image,
 				tt.version,
 				tt.channel,

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/jzelinskie/stringz v0.0.3 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -46,8 +46,6 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/jzelinskie/stringz v0.0.3 h1:0GhG3lVMYrYtIvRbxvQI6zqRTT1P1xyQlpa0FhfUXas=
-github.com/jzelinskie/stringz v0.0.3/go.mod h1:hHYbgxJuNLRw91CmpuFsYEOyQqpDVFg8pvEh23vy4P0=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=


### PR DESCRIPTION
There's a new startup flag `--base-image` that will take precedence over the image in the graph. This will make it easier to re-use the same graph artifact with mirrored images.

There's also a new `.spec.baseImage` field on SpiceDBCluster that allows overriding the base image per-cluster.