### PR TITLE
switch to maxUnavailable=1 and create PDB even if replicas=1

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -872,7 +872,7 @@ func (c *Config) unpatchedPDB() *applypolicyv1.PodDisruptionBudgetApplyConfigura
 				map[string]string{"app.kubernetes.io/instance": deploymentName(c.Name)},
 			)).
 			// only allow one pod to be unavailable at a time
-			WithMinAvailable(intstr.FromInt32(c.Replicas - 1)),
+			WithMaxUnavailable(intstr.FromInt32(1)),
 		)
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2669,7 +2669,7 @@ func TestPDB(t *testing.T) {
 		wantPDB *applypolicyv1.PodDisruptionBudgetApplyConfiguration
 	}{
 		{
-			name: "pdb sets minavailable to replicas - 1",
+			name: "pdb sets maxUnavailable to 1",
 			cluster: v1alpha1.ClusterSpec{
 				Config: json.RawMessage(`
 					{
@@ -2691,7 +2691,7 @@ func TestPDB(t *testing.T) {
 						applymetav1.LabelSelector().WithMatchLabels(map[string]string{
 							"app.kubernetes.io/instance": "test-spicedb",
 						}),
-					).WithMinAvailable(intstr.FromInt32(4))),
+					).WithMaxUnavailable(intstr.FromInt32(1))),
 		},
 		{
 			name: "patches preserve required fields",
@@ -2722,7 +2722,7 @@ metadata:
 						applymetav1.LabelSelector().WithMatchLabels(map[string]string{
 							"app.kubernetes.io/instance": "test-spicedb",
 						}),
-					).WithMinAvailable(intstr.FromInt32(1))),
+					).WithMaxUnavailable(intstr.FromInt32(1))),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
- switch to `maxUnavailable=1` so no SpiceDB pod is ever lost when nodes are cycled
- fixes left over PDB with invalid value when scaling from >1 to =1 replicas (works in tandem with ☝🏻 )