### PR TITLE
Add skipTLSWarning config option

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -92,6 +92,7 @@ var (
 	httpTLSCertPathKey                = newKey("httpTLSCertPath", DefaultTLSCrtFile)
 	dashboardTLSKeyPathKey            = newKey("dashboardTLSKeyPath", DefaultTLSKeyFile)
 	dashboardTLSCertPathKey           = newKey("dashboardTLSCertPath", DefaultTLSCrtFile)
+	skipTLSWarningKey                 = newBoolOrStringKey("skipTLSWarning", false)
 )
 
 // Warning is an issue with configuration that we will report as undesirable
@@ -169,6 +170,7 @@ type SpiceConfig struct {
 	EnvPrefix                      string
 	SpiceDBCmd                     string
 	TLSSecretName                  string
+	SkipTLSWarning                 bool
 	DispatchEnabled                bool
 	DispatchUpstreamCASecretName   string
 	DispatchUpstreamCASecretPath   string
@@ -268,6 +270,11 @@ func NewConfig(cluster *v1alpha1.SpiceDBCluster, globalConfig *OperatorConfig, s
 	}
 
 	spiceConfig.DispatchEnabled, err = dispatchEnabledKey.pop(config)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	spiceConfig.SkipTLSWarning, err = skipTLSWarningKey.pop(config)
 	if err != nil {
 		errs = append(errs, err)
 	}
@@ -435,7 +442,7 @@ func NewConfig(cluster *v1alpha1.SpiceDBCluster, globalConfig *OperatorConfig, s
 		for _, k := range passthroughKeys {
 			passthroughConfig[k.key] = k.pop(config)
 		}
-	} else {
+	} else if !spiceConfig.SkipTLSWarning {
 		warnings = append(warnings, fmt.Errorf("no TLS configured, consider setting %q", "tlsSecretName"))
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -364,12 +364,15 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "memory with skipTLSWarning",
 			args: args{
-				cluster: v1alpha1.ClusterSpec{Config: json.RawMessage(`
+				cluster: v1alpha1.ClusterSpec{
+					SecretRef: "test-secret",
+					Config: json.RawMessage(`
 					{
 						"datastoreEngine": "memory",
 						"skipTLSWarning": true
 					}
-				`)},
+				`),
+				},
 				globalConfig: OperatorConfig{
 					ImageName: "image",
 					UpdateGraph: updates.UpdateGraph{
@@ -421,6 +424,9 @@ func TestNewConfig(t *testing.T) {
 					ServiceAccountName:           "test",
 					DispatchEnabled:              false,
 					DispatchUpstreamCASecretPath: "tls.crt",
+					DatastoreURIRef:              ResolvedCredentialRef{SecretName: "test-secret", Key: "datastore_uri"},
+					PresharedKeyRef:              ResolvedCredentialRef{SecretName: "test-secret", Key: "preshared_key"},
+					MigrationSecretsRef:          ResolvedCredentialRef{SecretName: "test-secret", Key: "migration_secrets"},
 					ProjectLabels:                true,
 					ProjectAnnotations:           true,
 					Passthrough: map[string]string{

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -362,6 +362,85 @@ func TestNewConfig(t *testing.T) {
 			wantPortCount: 3,
 		},
 		{
+			name: "memory with skipTLSWarning",
+			args: args{
+				cluster: v1alpha1.ClusterSpec{Config: json.RawMessage(`
+					{
+						"datastoreEngine": "memory",
+						"skipTLSWarning": true
+					}
+				`)},
+				globalConfig: OperatorConfig{
+					ImageName: "image",
+					UpdateGraph: updates.UpdateGraph{
+						Channels: []updates.Channel{
+							{
+								Name:     "memory",
+								Metadata: map[string]string{"datastore": "memory", "default": "true"},
+								Nodes: []updates.State{
+									{ID: "v1", Tag: "v1"},
+								},
+								Edges: map[string][]string{"v1": {}},
+							},
+						},
+					},
+				},
+				secret: &corev1.Secret{Data: map[string][]byte{
+					"preshared_key": []byte("psk"),
+				}},
+			},
+			wantWarnings: nil,
+			want: &Config{
+				MigrationConfig: MigrationConfig{
+					MigrationLogLevel:  "debug",
+					DatastoreEngine:    "memory",
+					DatastoreURI:       "",
+					TargetSpiceDBImage: "image:v1",
+					EnvPrefix:          "SPICEDB",
+					SpiceDBCmd:         "spicedb",
+					TargetMigration:    "head",
+					SpiceDBVersion: &v1alpha1.SpiceDBVersion{
+						Name:    "v1",
+						Channel: "memory",
+						Attributes: []v1alpha1.SpiceDBVersionAttributes{
+							v1alpha1.SpiceDBVersionAttributesMigration,
+						},
+					},
+				},
+				SpiceConfig: SpiceConfig{
+					LogLevel:                     "info",
+					SkipMigrations:               false,
+					SkipTLSWarning:               true,
+					Name:                         "test",
+					Namespace:                    "test",
+					UID:                          "1",
+					Replicas:                     1,
+					PresharedKey:                 "psk",
+					EnvPrefix:                    "SPICEDB",
+					SpiceDBCmd:                   "spicedb",
+					ServiceAccountName:           "test",
+					DispatchEnabled:              false,
+					DispatchUpstreamCASecretPath: "tls.crt",
+					ProjectLabels:                true,
+					ProjectAnnotations:           true,
+					Passthrough: map[string]string{
+						"datastoreEngine":        "memory",
+						"dispatchClusterEnabled": "false",
+						"terminationLogPath":     "/dev/termination-log",
+					},
+				},
+			},
+			wantEnvs: []string{
+				"SPICEDB_POD_NAME=FIELD_REF=metadata.name",
+				"SPICEDB_LOG_LEVEL=info",
+				"SPICEDB_GRPC_PRESHARED_KEY=preshared_key",
+				"SPICEDB_DATASTORE_ENGINE=memory",
+				"SPICEDB_DISPATCH_CLUSTER_ENABLED=false",
+				"SPICEDB_TERMINATION_LOG_PATH=/dev/termination-log",
+			},
+			wantPortCount: 3,
+		},
+		{
 			name: "set image with tag explicitly",
 			args: args{
 				cluster: v1alpha1.ClusterSpec{


### PR DESCRIPTION
## Summary

Add a new config option `skipTLSWarning` that allows users to suppress the TLS warning in the Status.Conditions when running SpiceDB without TLS in internal/development environments.

Fixes #180

## Changes

- Add `skipTLSWarning` config key (boolean, defaults to `false`)
- Add `SkipTLSWarning` field to `SpiceConfig` struct
- Update TLS warning logic to check the flag
- Add test case for the new functionality

## Usage

```yaml
apiVersion: authzed.com/v1alpha1
kind: SpiceDBCluster
spec:
  config:
    datastoreEngine: memory
    skipTLSWarning: true  # Suppress TLS warning for internal deployments
```

## Testing

```sh
go test ./pkg/config/... -v -run "TestNewConfig/memory_with_skipTLSWarning"
```