### PR TITLE
each adoption handler only sees its own secret

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -610,7 +610,12 @@ func (c *Controller) secretAdopter(next ...handler.Handler) handler.Handler {
 					}
 					QueueOps.RequeueErr(ctx, err)
 				},
-				typed.MustIndexerForKey[*corev1.Secret](c.Registry, typed.NewRegistryKey(DependentFactoryKey(CtxCacheNamespace.Value(ctx)), secretsGVR)),
+				typed.NewIndexer[*corev1.Secret](newAdoptionAwareIndexer(
+				c.Registry.MustIndexerForKey(typed.NewRegistryKey(DependentFactoryKey(CtxCacheNamespace.Value(ctx)), secretsGVR)),
+				name,
+				cluster.Namespace,
+				names,
+			)),
 				func(ctx context.Context, secret *applycorev1.SecretApplyConfiguration, options metav1.ApplyOptions) (*corev1.Secret, error) {
 					return c.kclient.CoreV1().Secrets(*secret.Namespace).Apply(ctx, secret, options)
 				},

--- a/pkg/controller/secret_adoption.go
+++ b/pkg/controller/secret_adoption.go
@@ -4,8 +4,10 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
 	"github.com/authzed/controller-idioms/adopt"
@@ -15,6 +17,69 @@ import (
 
 	"github.com/authzed/spicedb-operator/pkg/metadata"
 )
+
+// adoptionAwareIndexer wraps a cache.Indexer and filters ByIndex results so
+// that other currently-valid adoptees are not misidentified as stale extras.
+//
+// When secretAdopter runs N AdoptionHandlers sequentially (one per secret),
+// each handler's cleanup loop removes labels from any indexed secret that isn't
+// its own adoptee. Without this wrapper, handler[i] strips the label from
+// handler[j]'s adoptee on every reconcile, creating an infinite re-adoption loop.
+//
+// This wrapper ensures each handler sees only:
+//   - Its own adoptee (so adoption proceeds normally), and
+//   - Truly stale secrets (not in validNames) so they are still cleaned up.
+//
+// Other currently-valid adoptees are hidden from each handler's ByIndex call.
+type adoptionAwareIndexer struct {
+	cache.Indexer
+	currentAdoptee string
+	namespace      string
+	validNames     map[string]struct{}
+}
+
+func newAdoptionAwareIndexer(base cache.Indexer, currentAdoptee, namespace string, allNames []string) *adoptionAwareIndexer {
+	valid := make(map[string]struct{}, len(allNames))
+	for _, n := range allNames {
+		valid[n] = struct{}{}
+	}
+	return &adoptionAwareIndexer{
+		Indexer:        base,
+		currentAdoptee: currentAdoptee,
+		namespace:      namespace,
+		validNames:     valid,
+	}
+}
+
+func (a *adoptionAwareIndexer) ByIndex(indexName, indexedValue string) ([]interface{}, error) {
+	objs, err := a.Indexer.ByIndex(indexName, indexedValue)
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]interface{}, 0, len(objs))
+	for _, obj := range objs {
+		m, err := meta.Accessor(obj)
+		if err != nil {
+			continue
+		}
+		name := m.GetName()
+		ns := m.GetNamespace()
+		// Objects in other namespaces are passed through unchanged.
+		if ns != a.namespace {
+			filtered = append(filtered, obj)
+			continue
+		}
+		// Always include the current adoptee.
+		// Include stale secrets (not in validNames) so cleanup removes them.
+		// Exclude other currently-valid adoptees to prevent incorrect cleanup.
+		if name == a.currentAdoptee {
+			filtered = append(filtered, obj)
+		} else if _, isValid := a.validNames[name]; !isValid {
+			filtered = append(filtered, obj)
+		}
+	}
+	return filtered, nil
+}
 
 const EventSecretAdoptedBySpiceDBCluster = "SecretAdoptedBySpiceDB"
 

--- a/pkg/controller/secretadopter_test.go
+++ b/pkg/controller/secretadopter_test.go
@@ -287,3 +287,62 @@ func TestControllerSecretAdopter(t *testing.T) {
 		})
 	}
 }
+
+// TestSecretAdopterMultipleSecretsNoSpuriousCleanup verifies that when two
+// secrets are both already adopted, secretAdopter makes no API calls.
+//
+// Regression test for a bug where N sequential AdoptionHandlers sharing the
+// same OwningClusterIndex would each clean up the other handler's valid
+// adoptee: handler[i] finds handler[j]'s secret in the index and removes its
+// label as if it were stale. This caused an infinite re-adoption loop.
+func TestSecretAdopterMultipleSecretsNoSpuriousCleanup(t *testing.T) {
+	const testNamespace = "test"
+	const clusterName = "mycluster"
+
+	ownerAnnotationKey := metadata.OwnerAnnotationKeyPrefix + clusterName
+	makeAdoptedSecret := func(name string) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testNamespace,
+				Labels:    map[string]string{metadata.OperatorManagedLabelKey: metadata.OperatorManagedLabelValue},
+				Annotations: map[string]string{
+					ownerAnnotationKey: "owned",
+				},
+			},
+		}
+	}
+
+	c, _ := newTestControllerForSecretAdopter(t, testNamespace, []*corev1.Secret{
+		makeAdoptedSecret("secret1"),
+		makeAdoptedSecret("secret2"),
+	})
+
+	handlerCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	ops := queue.NewOperations(cancel, func(_ time.Duration) { cancel() }, cancel)
+
+	cluster := &v1alpha1.SpiceDBCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: testNamespace},
+	}
+
+	ctx := handlerCtx
+	ctx = QueueOps.WithValue(ctx, ops)
+	ctx = CtxCacheNamespace.WithValue(ctx, testNamespace)
+	ctx = CtxCluster.WithValue(ctx, cluster)
+	ctx = CtxClusterNN.WithValue(ctx, types.NamespacedName{Namespace: testNamespace, Name: clusterName})
+	ctx = CtxSecretNames.WithValue(ctx, []string{"secret1", "secret2"})
+
+	nextCalled := false
+	c.secretAdopter(handler.NewHandlerFromFunc(func(_ context.Context) {
+		nextCalled = true
+	}, "testnext")).Handle(ctx)
+
+	require.True(t, nextCalled, "next should be called when both secrets are already adopted")
+
+	// When both secrets are already adopted, secretAdopter should make zero API
+	// calls. The bug caused handler[i] to issue two patches (annotation + label
+	// removal) against handler[j]'s secret on every reconcile.
+	require.Empty(t, c.kclient.(*kfake.Clientset).Actions(),
+		"secretAdopter must not issue any API calls when all secrets are already adopted")
+}


### PR DESCRIPTION
<!--
If your PR is not ready to be reviewed or merged, please submit it as a "draft".
-->

## Description

Intended to fix #409. Limits each secret adoption handler to managing its own secret, and prevents each one from discarding another secret managed by the operator as extra.

## Testing

Added unit test which failed prior to the change and succeeds after.

## References

<!--
GitHub Issue, Discord or Slack threads, etc.
-->