### PR TITLE
Enable CockroachDB rangefeeds in example for Watch API

### DIFF
--- a/examples/cockroachdb-tls-ingress/README.md
+++ b/examples/cockroachdb-tls-ingress/README.md
@@ -5,6 +5,7 @@ This will guide you through setting up a complete example SpiceDB cluster:
 - Managed by the operator
 - With multiple nodes that dispatch to each other (with TLS)
 - With a cockroachdb backing datastore
+- With the Watch API enabled (via CockroachDB rangefeeds)
 - With ingress (and TLS)
 
 ## Configure Root CA
@@ -109,6 +110,19 @@ EOF
 
 zed schema read
 ```
+
+## Watch API
+
+The CockroachDB configuration in this example enables [rangefeeds], which are required for the SpiceDB [Watch API]. A Kubernetes Job runs automatically to set `kv.rangefeed.enabled = true` on the CockroachDB cluster.
+
+You can verify rangefeeds are enabled by checking the CockroachDB cluster setting:
+
+```sh
+kubectl exec cockroachdb-0 -- cockroach sql --insecure --execute="SHOW CLUSTER SETTING kv.rangefeed.enabled;"
+```
+
+[rangefeeds]: https://www.cockroachlabs.com/docs/stable/create-and-configure-changefeeds.html
+[Watch API]: https://authzed.com/docs/spicedb/concepts/commands#watch
 
 ## Clean up
 

--- a/examples/cockroachdb-tls-ingress/database/crdb.yaml
+++ b/examples/cockroachdb-tls-ingress/database/crdb.yaml
@@ -154,3 +154,33 @@ spec:
         resources:
           requests:
             storage: 100Gi
+---
+# Enable rangefeeds so the SpiceDB Watch API works.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: crdb-enable-rangefeeds
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      initContainers:
+        - name: wait-for-crdb
+          image: cockroachdb/cockroach:v22.1.6
+          command:
+            - "/bin/bash"
+            - "-c"
+            - |
+              until /cockroach/cockroach sql --insecure --host=cockroachdb-public --execute="SELECT 1"; do
+                echo "waiting for CockroachDB..."
+                sleep 2
+              done
+      containers:
+        - name: enable-rangefeeds
+          image: cockroachdb/cockroach:v22.1.6
+          command:
+            - "/cockroach/cockroach"
+            - "sql"
+            - "--insecure"
+            - "--host=cockroachdb-public"
+            - "--execute=SET CLUSTER SETTING kv.rangefeed.enabled = true;"


### PR DESCRIPTION
## Summary
- Add a Kubernetes Job that enables `kv.rangefeed.enabled` on CockroachDB, required for SpiceDB's Watch API
- Add README section explaining Watch API and how to verify rangefeeds are enabled

Closes #77