### PR TITLE
feat: support configurable PodDisruptionBudget

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -93,6 +93,10 @@ var (
 	dashboardTLSKeyPathKey            = newKey("dashboardTLSKeyPath", DefaultTLSKeyFile)
 	dashboardTLSCertPathKey           = newKey("dashboardTLSCertPath", DefaultTLSCrtFile)
 	skipTLSWarningKey                 = newBoolOrStringKey("skipTLSWarning", false)
+	pdbKey                            = "pdb"
+	pdbDisabledSubKey                 = newBoolOrStringKey("disabled", false)
+	pdbMaxUnavailableSubKey           = newStringKey("maxUnavailable")
+	pdbMinAvailableSubKey             = newStringKey("minAvailable")
 )
 
 // Warning is an issue with configuration that we will report as undesirable
@@ -185,6 +189,14 @@ type SpiceConfig struct {
 	ProjectLabels                  bool
 	ProjectAnnotations             bool
 	Passthrough                    map[string]string
+	PDB                            PDBConfig
+}
+
+// PDBConfig holds the configuration for the PodDisruptionBudget.
+type PDBConfig struct {
+	Disabled       bool
+	MaxUnavailable *intstr.IntOrString
+	MinAvailable   *intstr.IntOrString
 }
 
 // NewConfig checks that the values in the config + the secrets are sane
@@ -425,6 +437,39 @@ func NewConfig(cluster *v1alpha1.SpiceDBCluster, globalConfig *OperatorConfig, s
 	}
 	if len(saAnnotationWarnings) > 0 {
 		warnings = append(warnings, saAnnotationWarnings...)
+	}
+
+	if pdbRaw, ok := config[pdbKey]; ok {
+		delete(config, pdbKey)
+		pdbMap, ok := pdbRaw.(map[string]any)
+		if !ok {
+			errs = append(errs, fmt.Errorf("expected object for key %q", pdbKey))
+		} else {
+			pdbConfig := RawConfig(pdbMap)
+
+			spiceConfig.PDB.Disabled, err = pdbDisabledSubKey.pop(pdbConfig)
+			if err != nil {
+				errs = append(errs, err)
+			}
+
+			if s := pdbMaxUnavailableSubKey.pop(pdbConfig); s != "" {
+				val := parseIntOrStringValue(s)
+				spiceConfig.PDB.MaxUnavailable = &val
+			}
+
+			if s := pdbMinAvailableSubKey.pop(pdbConfig); s != "" {
+				val := parseIntOrStringValue(s)
+				spiceConfig.PDB.MinAvailable = &val
+			}
+
+			if spiceConfig.PDB.MaxUnavailable != nil && spiceConfig.PDB.MinAvailable != nil {
+				errs = append(errs, fmt.Errorf("only one of pdb.maxUnavailable or pdb.minAvailable can be set"))
+			}
+
+			for k := range pdbConfig {
+				warnings = append(warnings, fmt.Errorf("unknown key %q in pdb config", k))
+			}
+		}
 	}
 
 	// generate secret refs for tls if specified
@@ -981,15 +1026,23 @@ func (c *Config) PodDisruptionBudget() *applypolicyv1.PodDisruptionBudgetApplyCo
 }
 
 func (c *Config) unpatchedPDB() *applypolicyv1.PodDisruptionBudgetApplyConfiguration {
+	spec := applypolicyv1.PodDisruptionBudgetSpec().
+		WithSelector(applymetav1.LabelSelector().WithMatchLabels(
+			map[string]string{metadata.KubernetesInstanceLabelKey: deploymentName(c.Name)},
+		))
+
+	switch {
+	case c.PDB.MaxUnavailable != nil:
+		spec = spec.WithMaxUnavailable(*c.PDB.MaxUnavailable)
+	case c.PDB.MinAvailable != nil:
+		spec = spec.WithMinAvailable(*c.PDB.MinAvailable)
+	default:
+		spec = spec.WithMaxUnavailable(intstr.FromInt32(1))
+	}
+
 	return applypolicyv1.PodDisruptionBudget(pdbName(c.Name), c.Namespace).
 		WithLabels(metadata.LabelsForComponent(c.Name, metadata.ComponentPDBLabel)).
-		WithSpec(applypolicyv1.PodDisruptionBudgetSpec().
-			WithSelector(applymetav1.LabelSelector().WithMatchLabels(
-				map[string]string{metadata.KubernetesInstanceLabelKey: deploymentName(c.Name)},
-			)).
-			// only allow one pod to be unavailable at a time
-			WithMaxUnavailable(intstr.FromInt32(1)),
-		)
+		WithSpec(spec)
 }
 
 func (c *Config) commonLabels(name string) map[string]string {
@@ -1106,4 +1159,13 @@ func deploymentName(name string) string {
 // pdbName returns the name of the unpatchedPDB given a SpiceDBCluster name
 func pdbName(name string) string {
 	return fmt.Sprintf("%s-spicedb", name)
+}
+
+// parseIntOrStringValue parses a string as an integer or, if that fails,
+// returns it as a string-typed IntOrString (e.g. for percentage values like "50%").
+func parseIntOrStringValue(s string) intstr.IntOrString {
+	if v, err := strconv.ParseInt(s, 10, 32); err == nil {
+		return intstr.FromInt32(int32(v))
+	}
+	return intstr.FromString(s)
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -949,7 +949,7 @@ func TestNewConfig(t *testing.T) {
 					Config: json.RawMessage(`
 					{
 						"datastoreEngine": "cockroachdb",
-						"skipMigrations": true	
+						"skipMigrations": true
 					}
 				`),
 				},
@@ -1038,7 +1038,7 @@ func TestNewConfig(t *testing.T) {
 					Config: json.RawMessage(`
 					{
 						"datastoreEngine": "cockroachdb",
-						"skipMigrations": "true"	
+						"skipMigrations": "true"
 					}
 				`),
 				},
@@ -2649,7 +2649,7 @@ metadata:
 				Patches: []v1alpha1.Patch{{
 					Kind: "Deployment",
 					Patch: json.RawMessage(`
-      spec: 
+      spec:
         template: null
 `),
 				}},
@@ -2728,7 +2728,7 @@ metadata:
 				Patches: []v1alpha1.Patch{{
 					Kind: "Job",
 					Patch: json.RawMessage(`
-      spec: 
+      spec:
         template: null
 `),
 				}},
@@ -3183,9 +3183,11 @@ metadata:
 func TestPDB(t *testing.T) {
 	resources := newFakeResources()
 	tests := []struct {
-		name    string
-		cluster v1alpha1.ClusterSpec
-		wantPDB *applypolicyv1.PodDisruptionBudgetApplyConfiguration
+		name           string
+		cluster        v1alpha1.ClusterSpec
+		wantPDB        *applypolicyv1.PodDisruptionBudgetApplyConfiguration
+		wantPDBDisabled bool
+		wantErr        error
 	}{
 		{
 			name: "pdb sets maxUnavailable to 1",
@@ -3257,6 +3259,164 @@ metadata:
 						}),
 					).WithMaxUnavailable(intstr.FromInt32(1))),
 		},
+		{
+			name: "invalid pdb config returns error",
+			cluster: v1alpha1.ClusterSpec{
+				SecretRef: "test-secret",
+				Config: json.RawMessage(`
+					{
+						"datastoreEngine": "cockroachdb",
+						"pdb": "foo"
+					}
+				`),
+			},
+			wantErr: fmt.Errorf("expected object for key %q", pdbKey),
+		},
+		{
+			name: "invalid pdb.disabled value returns error",
+			cluster: v1alpha1.ClusterSpec{
+				SecretRef: "test-secret",
+				Config: json.RawMessage(`
+					{
+						"datastoreEngine": "cockroachdb",
+						"pdb": {
+							"disabled": 1
+						}
+					}
+				`),
+			},
+			wantErr: fmt.Errorf("expected bool or string for key disabled"),
+		},
+		{
+			name: "pdb disabled",
+			cluster: v1alpha1.ClusterSpec{
+				SecretRef: "test-secret",
+				Config: json.RawMessage(`
+					{
+						"datastoreEngine": "cockroachdb",
+						"pdb": {
+							"disabled": true
+						}
+					}
+				`),
+			},
+			wantPDBDisabled: true,
+		},
+		{
+			name: "pdb with custom maxUnavailable integer",
+			cluster: v1alpha1.ClusterSpec{
+				SecretRef: "test-secret",
+				Config: json.RawMessage(`
+					{
+						"datastoreEngine": "cockroachdb",
+						"pdb": {
+							"maxUnavailable": "2"
+						}
+					}
+				`),
+			},
+			wantPDB: applypolicyv1.PodDisruptionBudget("test-spicedb", "test").
+				WithLabels(metadata.LabelsForComponent("test", metadata.ComponentPDBLabel)).
+				WithLabels(map[string]string{
+					metadata.KubernetesInstanceLabelKey:  "test-spicedb",
+					metadata.KubernetesNameLabelKey:      "test-spicedb",
+					metadata.KubernetesComponentLabelKey: metadata.ComponentSpiceDBLabelValue,
+					metadata.KubernetesVersionLabelKey:   "v1",
+				}).
+				WithOwnerReferences(applymetav1.OwnerReference().
+					WithName("test").
+					WithKind(v1alpha1.SpiceDBClusterKind).
+					WithAPIVersion(v1alpha1.SchemeGroupVersion.String()).
+					WithUID("1")).
+				WithSpec(
+					applypolicyv1.PodDisruptionBudgetSpec().WithSelector(
+						applymetav1.LabelSelector().WithMatchLabels(map[string]string{
+							metadata.KubernetesInstanceLabelKey: "test-spicedb",
+						}),
+					).WithMaxUnavailable(intstr.FromInt32(2))),
+		},
+		{
+			name: "pdb with custom maxUnavailable percentage",
+			cluster: v1alpha1.ClusterSpec{
+				SecretRef: "test-secret",
+				Config: json.RawMessage(`
+					{
+						"datastoreEngine": "cockroachdb",
+						"pdb": {
+							"maxUnavailable": "50%"
+						}
+					}
+				`),
+			},
+			wantPDB: applypolicyv1.PodDisruptionBudget("test-spicedb", "test").
+				WithLabels(metadata.LabelsForComponent("test", metadata.ComponentPDBLabel)).
+				WithLabels(map[string]string{
+					metadata.KubernetesInstanceLabelKey:  "test-spicedb",
+					metadata.KubernetesNameLabelKey:      "test-spicedb",
+					metadata.KubernetesComponentLabelKey: metadata.ComponentSpiceDBLabelValue,
+					metadata.KubernetesVersionLabelKey:   "v1",
+				}).
+				WithOwnerReferences(applymetav1.OwnerReference().
+					WithName("test").
+					WithKind(v1alpha1.SpiceDBClusterKind).
+					WithAPIVersion(v1alpha1.SchemeGroupVersion.String()).
+					WithUID("1")).
+				WithSpec(
+					applypolicyv1.PodDisruptionBudgetSpec().WithSelector(
+						applymetav1.LabelSelector().WithMatchLabels(map[string]string{
+							metadata.KubernetesInstanceLabelKey: "test-spicedb",
+						}),
+					).WithMaxUnavailable(intstr.FromString("50%"))),
+		},
+		{
+			name: "pdb with custom minAvailable",
+			cluster: v1alpha1.ClusterSpec{
+				SecretRef: "test-secret",
+				Config: json.RawMessage(`
+					{
+						"datastoreEngine": "cockroachdb",
+						"pdb": {
+							"minAvailable": "3"
+						}
+					}
+				`),
+			},
+			wantPDB: applypolicyv1.PodDisruptionBudget("test-spicedb", "test").
+				WithLabels(metadata.LabelsForComponent("test", metadata.ComponentPDBLabel)).
+				WithLabels(map[string]string{
+					metadata.KubernetesInstanceLabelKey:  "test-spicedb",
+					metadata.KubernetesNameLabelKey:      "test-spicedb",
+					metadata.KubernetesComponentLabelKey: metadata.ComponentSpiceDBLabelValue,
+					metadata.KubernetesVersionLabelKey:   "v1",
+				}).
+				WithOwnerReferences(applymetav1.OwnerReference().
+					WithName("test").
+					WithKind(v1alpha1.SpiceDBClusterKind).
+					WithAPIVersion(v1alpha1.SchemeGroupVersion.String()).
+					WithUID("1")).
+				WithSpec(
+					applypolicyv1.PodDisruptionBudgetSpec().WithSelector(
+						applymetav1.LabelSelector().WithMatchLabels(map[string]string{
+							metadata.KubernetesInstanceLabelKey: "test-spicedb",
+						}),
+					).WithMinAvailable(intstr.FromInt32(3))),
+		},
+		{
+			name: "pdb with both maxUnavailable and minAvailable returns error",
+			cluster: v1alpha1.ClusterSpec{
+				SecretRef: "test-secret",
+				Config: json.RawMessage(`
+					{
+						"datastoreEngine": "cockroachdb",
+						"pdb": {
+							"maxUnavailable": "1",
+							"minAvailable": "1"
+						}
+					}
+				`),
+			},
+			wantErr: fmt.Errorf("only one of pdb.maxUnavailable or pdb.minAvailable can be set"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -3273,14 +3433,21 @@ metadata:
 				Spec: tt.cluster,
 			}
 			got, _, err := NewConfig(cluster, ptr.To(testGlobalConfig.Copy()), singleSecretMap("test-secret", secret), resources)
+			if tt.wantErr != nil {
+				require.ErrorContains(t, err, tt.wantErr.Error())
+				return
+			}
 			require.NoError(t, err)
 
-			wantPDB, err := json.Marshal(tt.wantPDB)
-			require.NoError(t, err)
-			gotPDB, err := json.Marshal(got.PodDisruptionBudget())
-			require.NoError(t, err)
+			require.Equal(t, tt.wantPDBDisabled, got.PDB.Disabled)
 
-			require.JSONEq(t, string(wantPDB), string(gotPDB))
+			if tt.wantPDB != nil {
+				wantPDB, err := json.Marshal(tt.wantPDB)
+				require.NoError(t, err)
+				gotPDB, err := json.Marshal(got.PodDisruptionBudget())
+				require.NoError(t, err)
+				require.JSONEq(t, string(wantPDB), string(gotPDB))
+			}
 		})
 	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -3183,11 +3183,11 @@ metadata:
 func TestPDB(t *testing.T) {
 	resources := newFakeResources()
 	tests := []struct {
-		name           string
-		cluster        v1alpha1.ClusterSpec
-		wantPDB        *applypolicyv1.PodDisruptionBudgetApplyConfiguration
+		name            string
+		cluster         v1alpha1.ClusterSpec
+		wantPDB         *applypolicyv1.PodDisruptionBudgetApplyConfiguration
 		wantPDBDisabled bool
-		wantErr        error
+		wantErr         error
 	}{
 		{
 			name: "pdb sets maxUnavailable to 1",

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -557,9 +557,28 @@ func (c *Controller) ensurePDB(next ...handler.Handler) handler.Handler {
 			},
 		)
 
+		cfg := CtxConfig.MustValue(ctx)
+
+		// If PDB is disabled, delete any existing PDB and skip creation
+		if cfg.PDB.Disabled {
+			clusterName := CtxClusterNN.MustValue(ctx).Name
+			expectedLabels := metadata.LabelsForComponent(clusterName, metadata.ComponentPDBLabel)
+			for _, pdb := range pdbComponent.List(ctx, CtxClusterNN.MustValue(ctx)) {
+				if !hasAllLabels(pdb.Labels, expectedLabels) {
+					logr.FromContextOrDiscard(ctx).V(4).Info("skipping pdb deletion: missing operator labels", "namespace", pdb.Namespace, "name", pdb.Name)
+					continue
+				}
+				nn := types.NamespacedName{Name: pdb.Name, Namespace: pdb.Namespace}
+				if err := deletePDB(ctx, nn); err != nil && !apierrors.IsNotFound(err) {
+					logr.FromContextOrDiscard(ctx).Error(err, "error deleting pdb")
+				}
+			}
+			handler.Handlers(next).MustOne().Handle(ctx)
+			return
+		}
+
 		// build the handler that ensures the PDB with the proper definition
 		// exists and run it
-		cfg := CtxConfig.MustValue(ctx)
 		component.NewEnsureComponentByHash(
 			component.NewHashableComponent(pdbComponent, hash.NewObjectHash(), "authzed.com/controller-component-hash"),
 			CtxClusterNN,
@@ -953,4 +972,13 @@ func (c *Controller) ensureService(next ...handler.Handler) handler.Handler {
 		}
 		handler.Handlers(next).MustOne().Handle(ctx)
 	}, "ensureService")
+}
+
+func hasAllLabels(actual, expected map[string]string) bool {
+	for k, v := range expected {
+		if actual[k] != v {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -6,10 +6,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/authzed/controller-idioms/handler"
+	queuefake "github.com/authzed/controller-idioms/queue/fake"
 	"github.com/authzed/controller-idioms/typed"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/dynamic/fake"
 	kfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -17,6 +22,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/authzed/spicedb-operator/pkg/apis/authzed/v1alpha1"
+	"github.com/authzed/spicedb-operator/pkg/config"
 	"github.com/authzed/spicedb-operator/pkg/metadata"
 )
 
@@ -285,6 +291,124 @@ func TestCredentialSecretsForCluster(t *testing.T) {
 				},
 			}
 			require.Equal(t, tt.expect, credentialSecretsForCluster(cluster))
+		})
+	}
+}
+
+func TestEnsurePDB(t *testing.T) {
+	var nextKey handler.Key = "next"
+	maxUnavailable2 := intstr.FromInt32(2)
+	minAvailable50pct := intstr.FromString("50%")
+
+	tests := []struct {
+		name        string
+		pdbConfig   config.PDBConfig
+		existingPDB *policyv1.PodDisruptionBudget
+
+		expectNext   bool
+		expectApply  bool
+		expectDelete bool
+	}{
+		{
+			name:        "calls next without creating PDB when disabled",
+			pdbConfig:   config.PDBConfig{Disabled: true},
+			expectNext:  true,
+			expectApply: false,
+		},
+		{
+			name:        "creates PDB with default max unavailable when not disabled",
+			pdbConfig:   config.PDBConfig{},
+			expectApply: true,
+			expectNext:  true,
+		},
+		{
+			name:        "creates PDB with custom MaxUnavailable",
+			pdbConfig:   config.PDBConfig{MaxUnavailable: &maxUnavailable2},
+			expectApply: true,
+			expectNext:  true,
+		},
+		{
+			name:        "creates PDB with MinAvailable",
+			pdbConfig:   config.PDBConfig{MinAvailable: &minAvailable50pct},
+			expectApply: true,
+			expectNext:  true,
+		},
+		{
+			name:      "deletes managed PDB when disabled",
+			pdbConfig: config.PDBConfig{Disabled: true},
+			existingPDB: &policyv1.PodDisruptionBudget{
+				TypeMeta: metav1.TypeMeta{Kind: "PodDisruptionBudget", APIVersion: "policy/v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster-pdb",
+					Namespace: "test-ns",
+					Labels:    metadata.LabelsForComponent("test-cluster", metadata.ComponentPDBLabel),
+				},
+			},
+			expectDelete: true,
+			expectNext:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			registry := typed.NewRegistry()
+			broadcaster := record.NewBroadcaster()
+			dclient := fake.NewSimpleDynamicClient(scheme.Scheme)
+			if tt.existingPDB != nil {
+				dclient = fake.NewSimpleDynamicClient(scheme.Scheme, tt.existingPDB)
+			}
+			kclient := kfake.NewClientset()
+			c, err := NewController(ctx, registry, dclient, kclient, nil, "", "", broadcaster, nil)
+			require.NoError(t, err)
+
+			ctrls := &queuefake.FakeInterface{}
+			var called handler.Key
+			nextHandler := handler.NewHandlerFromFunc(func(_ context.Context) {
+				called = nextKey
+			}, nextKey)
+
+			cfg := &config.Config{
+				SpiceConfig: config.SpiceConfig{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+					PDB:       tt.pdbConfig,
+				},
+			}
+
+			// CtxCacheNamespace must be "" to match the all-namespaces factory key
+			// registered when NewController is called with nil namespaces.
+			ctx = CtxCacheNamespace.WithValue(ctx, "")
+			ctx = CtxClusterNN.WithValue(ctx, types.NamespacedName{Name: "test-cluster", Namespace: "test-ns"})
+			ctx = CtxConfig.WithValue(ctx, cfg)
+			ctx = QueueOps.WithValue(ctx, ctrls)
+
+			h := c.ensurePDB(nextHandler)
+			h.Handle(ctx)
+
+			applyFound := false
+			deleteFound := false
+			for _, a := range kclient.Actions() {
+				if a.GetResource().Resource != "poddisruptionbudgets" {
+					continue
+				}
+				switch a.GetVerb() {
+				case "patch":
+					applyFound = true
+				case "delete":
+					deleteFound = true
+				}
+			}
+
+			require.Equal(t, tt.expectApply, applyFound, "applyPDB call")
+			require.Equal(t, tt.expectDelete, deleteFound, "deletePDB call")
+			if tt.expectNext {
+				require.Equal(t, nextKey, called, "next handler called")
+			} else {
+				require.NotEqual(t, nextKey, called, "next handler not called")
+			}
 		})
 	}
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -135,8 +135,7 @@ func TestControllerNamespacing(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			t.Cleanup(cancel)
+			ctx := t.Context()
 			registry := typed.NewRegistry()
 			broadcaster := record.NewBroadcaster()
 			dclient := fake.NewSimpleDynamicClient(scheme.Scheme)
@@ -351,8 +350,7 @@ func TestEnsurePDB(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			t.Cleanup(cancel)
+			ctx := t.Context()
 
 			registry := typed.NewRegistry()
 			broadcaster := record.NewBroadcaster()


### PR DESCRIPTION
## Summary

Resolves #414.

Adds a new `pdb` config object on `SpiceDBCluster` to give users control over the PodDisruptionBudget:

- **`pdb.disabled`** (`bool`, default `false`): when `true`, the operator deletes any existing PDB owned by the cluster and stops creating one
- **`pdb.maxUnavailable`** (integer or percentage string, e.g. `"2"` or `"50%"`): sets the PDB's `maxUnavailable` field; defaults to `1` when neither field is set (preserving existing behavior)
- **`pdb.minAvailable`** (integer or percentage string): sets the PDB's `minAvailable` field; mutually exclusive with `pdb.maxUnavailable`

### Example usage

```yaml
# Disable PDB
spec:
  config:
    pdb:
      disabled: true

# Allow 50% of pods to be unavailable during disruptions
spec:
  config:
    pdb:
      maxUnavailable: "50%"

# Require at least 3 pods to always be available
spec:
  config:
    pdb:
      minAvailable: "3"
```

## Test plan

- [x] All existing unit tests pass
- [x] New unit tests added for: disabled PDB, custom `maxUnavailable` (integer and percentage), custom `minAvailable`, and validation error when both are set
- [x] `go test ./pkg/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)