### PR TITLE
fix: avoid panic when all credential refs are skipped

### DIFF
--- a/pkg/controller/ensure_deployment.go
+++ b/pkg/controller/ensure_deployment.go
@@ -43,7 +43,10 @@ func (m *DeploymentHandler) Handle(ctx context.Context) {
 	}
 
 	migrationHash := CtxMigrationHash.MustValue(ctx)
-	secretHash := CtxSecretHash.MustValue(ctx)
+	// secretHash may be empty when all credentials are configured with `skip: true`,
+	// since there is nothing to hash in that case. Use Value (not MustValue) so we
+	// fall back to the zero value rather than panic.
+	secretHash := CtxSecretHash.Value(ctx)
 	config := CtxConfig.MustValue(ctx)
 	newDeployment := config.Deployment(migrationHash, secretHash)
 	deploymentHash := hash.Object(newDeployment)

--- a/pkg/controller/ensure_deployment_test.go
+++ b/pkg/controller/ensure_deployment_test.go
@@ -29,6 +29,7 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 
 		migrationHash       string
 		secretHash          string
+		skipSecretHash      bool
 		existingDeployments []*appsv1.Deployment
 		pods                []*corev1.Pod
 		currentStatus       *v1alpha1.SpiceDBCluster
@@ -46,6 +47,18 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			name:               "creates if no deployments",
 			migrationHash:      "testtesttesttest",
 			secretHash:         "secret",
+			expectApply:        true,
+			expectRequeueAfter: true,
+		},
+		{
+			// Regression test for https://github.com/authzed/spicedb-operator/issues/415
+			// When all credential refs are configured with `skip: true`, ConfigChangedHandler
+			// never sets CtxSecretHash because there is nothing to hash. The handler must
+			// tolerate an unset/empty secret hash instead of panicking via MustValue on a
+			// defaulting context key.
+			name:               "creates if no deployments and secret hash is unset",
+			migrationHash:      "testtesttesttest",
+			skipSecretHash:     true,
 			expectApply:        true,
 			expectRequeueAfter: true,
 		},
@@ -385,7 +398,9 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 			ctx = QueueOps.WithValue(ctx, ctrls)
 			ctx = CtxCluster.WithValue(ctx, tt.currentStatus)
 			ctx = CtxMigrationHash.WithValue(ctx, tt.migrationHash)
-			ctx = CtxSecretHash.WithValue(ctx, tt.secretHash)
+			if !tt.skipSecretHash {
+				ctx = CtxSecretHash.WithValue(ctx, tt.secretHash)
+			}
 			ctx = CtxDeployments.WithValue(ctx, tt.existingDeployments)
 
 			var called handler.Key


### PR DESCRIPTION
Fixes #415.

When both `credentials.datastoreURI.skip` and `credentials.presharedKey.skip` are `true`, `ConfigChangedHandler` never sets `CtxSecretHash` (nothing to hash). `DeploymentHandler` then called `CtxSecretHash.MustValue`, which panics on a `DefaultingKey[string]` when the value is unset:

```
panic="could not find non-nil value for key *typedctx.DefaultingKey[string] in context"
```

The secret hash only exists to annotate the pod template so a rollout is triggered when the referenced secret data changes. When credentials are injected out-of-band there is nothing to hash and an empty annotation is correct. Switching to `Value` returns the zero value without panicking.