### PR TITLE
Reject pinned versions that are not in the update graph

### DIFF
--- a/pkg/updates/file.go
+++ b/pkg/updates/file.go
@@ -275,6 +275,10 @@ func (g *UpdateGraph) ComputeTarget(operatorImageName, clusterBaseImage, image, 
 	// If version is explicit, and there's no current version yet, just install
 	if len(version) > 0 && (currentVersion == nil || len(currentVersion.Name) == 0) {
 		state = updateSource.State(version)
+		if len(state.ID) == 0 {
+			err = fmt.Errorf("version %q is not in the update graph", version)
+			return baseImage, target, State{}, err
+		}
 		target.Name = state.ID
 		target.Attributes = []v1alpha1.SpiceDBVersionAttributes{v1alpha1.SpiceDBVersionAttributesMigration}
 		return baseImage, target, state, err
@@ -288,6 +292,7 @@ func (g *UpdateGraph) ComputeTarget(operatorImageName, clusterBaseImage, image, 
 	}
 
 	var currentState State
+	var notInChannel bool
 	if currentVersion != nil {
 		currentState = updateSource.State(currentVersion.Name)
 
@@ -303,6 +308,7 @@ func (g *UpdateGraph) ComputeTarget(operatorImageName, clusterBaseImage, image, 
 			currentState = source.State(currentVersion.Name)
 			target.Channel = currentVersion.Channel
 			target.Attributes = append(target.Attributes, v1alpha1.SpiceDBVersionAttributesNotInChannel)
+			notInChannel = true
 		}
 	}
 
@@ -323,7 +329,11 @@ func (g *UpdateGraph) ComputeTarget(operatorImageName, clusterBaseImage, image, 
 
 	// If currentVersion is set, we only use the subset of the update graph that leads
 	// to that currentVersion.
-	if currentVersion != nil && len(version) > 0 {
+	//
+	// Skip this when the current version isn't in the target channel (a channel
+	// switch that hasn't happened yet): the pinned version legitimately isn't a node
+	// here, and we stay on the current version below rather than erroring.
+	if currentVersion != nil && len(version) > 0 && !notInChannel {
 		updateSource, err = updateSource.Subgraph(version)
 		if err != nil {
 			err = fmt.Errorf("error finding update path from %s to %s", currentVersion.Name, version)

--- a/pkg/updates/file_test.go
+++ b/pkg/updates/file_test.go
@@ -632,6 +632,44 @@ func TestComputeTarget(t *testing.T) {
 			},
 			expectedState: State{ID: "v1.0.1"},
 		},
+		{
+			// A pinned version that isn't a node in the graph must error rather than
+			// silently re-rooting at (and marching to) the channel head.
+			name: "explicit version not in the update graph errors instead of advancing to head",
+			graph: &UpdateGraph{Channels: []Channel{{
+				Name:     "cockroachdb",
+				Metadata: map[string]string{"datastore": "cockroachdb"},
+				Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}},
+				Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
+			}}},
+			engine:            "cockroachdb",
+			operatorImageName: "ghcr.io/authzed/spicedb",
+			currentVersion:    &v1alpha1.SpiceDBVersion{Name: "v1.0.0", Channel: "cockroachdb"},
+			version:           "v2.0.0",
+			expectedBaseImage: "ghcr.io/authzed/spicedb",
+			expectedTarget:    &v1alpha1.SpiceDBVersion{Name: "v1.0.0", Channel: "cockroachdb"},
+			expectedState:     State{},
+			expectedErr:       "v2.0.0",
+		},
+		{
+			// Same unknown pinned version, but on a fresh install (no current version).
+			// It must error rather than installing an empty/unknown target.
+			name: "explicit version not in the update graph errors on fresh install",
+			graph: &UpdateGraph{Channels: []Channel{{
+				Name:     "cockroachdb",
+				Metadata: map[string]string{"datastore": "cockroachdb"},
+				Edges:    EdgeSet{"v1.0.0": {"v1.0.1"}},
+				Nodes:    []State{{ID: "v1.0.1"}, {ID: "v1.0.0"}},
+			}}},
+			engine:            "cockroachdb",
+			channel:           "cockroachdb",
+			operatorImageName: "ghcr.io/authzed/spicedb",
+			version:           "v2.0.0",
+			expectedBaseImage: "ghcr.io/authzed/spicedb",
+			expectedTarget:    &v1alpha1.SpiceDBVersion{Channel: "cockroachdb"},
+			expectedState:     State{},
+			expectedErr:       "v2.0.0",
+		},
 	}
 
 	for _, tt := range table {

--- a/pkg/updates/memory.go
+++ b/pkg/updates/memory.go
@@ -69,7 +69,11 @@ func (m *MemorySource) Subgraph(head string) (Source, error) {
 	// copy the ordered node list from `to` onward
 	var index int
 	if len(head) > 0 {
-		index = m.Nodes[head]
+		var ok bool
+		index, ok = m.Nodes[head]
+		if !ok {
+			return nil, fmt.Errorf("version %q is not in the update graph", head)
+		}
 	}
 	orderedNodes := make([]State, len(m.OrderedNodes)-index)
 	copy(orderedNodes, m.OrderedNodes[index:len(m.OrderedNodes)])

--- a/pkg/updates/memory_test.go
+++ b/pkg/updates/memory_test.go
@@ -348,3 +348,19 @@ func TestMemorySourceState(t *testing.T) {
 		})
 	}
 }
+
+// TestSubgraphRejectsUnknownHead ensures that re-rooting the graph at a version
+// that is not a node returns an error, rather than silently falling back to the
+// channel head. A missing key in the node map yields index 0 (the head), so an
+// unknown pinned version would otherwise resolve to "latest" with no error and
+// march the cluster forward.
+func TestSubgraphRejectsUnknownHead(t *testing.T) {
+	m, err := NewMemorySource(
+		[]State{{ID: "v2", Tag: "tag", Migration: "migration"}, {ID: "v1", Tag: "tag", Migration: "migration"}},
+		EdgeSet{"v1": {"v2"}},
+	)
+	require.NoError(t, err)
+
+	_, err = m.Subgraph("does-not-exist")
+	require.Error(t, err, "Subgraph must reject an unknown head instead of silently resolving to the channel head")
+}


### PR DESCRIPTION
## Problem

An explicit `spec.version` (channel pin) that does **not** exist as a node in the channel's update graph was silently resolved to the channel **head**, so the cluster was walked one hop per reconcile all the way to the latest version instead of failing.

Root cause: `MemorySource.Subgraph` looked up the node index with `index = m.Nodes[head]` and **ignored the missing-key case**. A Go map miss returns `0`, i.e. `OrderedNodes[0]` — the head — so re-rooting the graph at an unknown version produced the full graph with no error. `ComputeTarget` then took the normal `NextVersion` path toward head.

## Fix

- `MemorySource.Subgraph` now returns an error for an unknown non-empty `head` (`version %q is not in the update graph`). This lights up the error path `ComputeTarget` already had at the `Subgraph(version)` call site, which surfaces as a `ValidatingFailed` condition on the SpiceDBCluster.
- `ComputeTarget` also rejects an unknown explicit version on **fresh install** (the `len(version) > 0 && currentVersion == nil` branch used `State(version)` and silently produced an empty target).

A *valid* pin (including a far-off intermediate one) is unaffected: it already re-roots correctly via `Subgraph(pin)`.

### Why the `notInChannel` guard is needed

Making `Subgraph` error on an unknown head is **not safe on its own** — it would have broken the legitimate channel-switch path. During a channel switch the current version may not yet be a node in the *target* channel; in that case `ComputeTarget` deliberately calls `Subgraph(version)` with a version that isn't in the target channel and previously relied on the silent fallback to stay on the current version (marked `NotInChannel`). With `Subgraph` now erroring, that path would start failing (`error finding update path from <v> to <v>`).

A `notInChannel` guard skips the `Subgraph` re-root in exactly that case, so the cluster still stays put (`NotInChannel`) instead of erroring. The new error path therefore only applies when the current version **is** in the channel but the pinned target isn't reachable.

## Tests (TDD)

- `TestSubgraphRejectsUnknownHead` (`memory_test.go`) — `Subgraph` errors on an unknown head instead of silently returning the channel head.
- `TestComputeTarget` (`file_test.go`) — two new cases: an unknown pinned version on a running cluster, and on fresh install; both now error instead of advancing to head.
- The channel-switch regression described above is covered by the **existing** `TestComputeTarget` case *"switching channel, current version is not in the target channel"* (a pin whose current version isn't yet in the target channel): it stays put with `NotInChannel`, and fails if the `notInChannel` guard is removed.

Changed files: `pkg/updates/{memory.go, file.go, memory_test.go, file_test.go}`. `pkg/updates` and `pkg/config` pass; `gofmt`, `go vet`, and `golangci-lint` are clean.