### PR TITLE
fix: skipMigrations deployments shouldn't claim the real migration hash

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1002,10 +1002,20 @@ func (c *Config) Deployment(migrationHash, secretHash string) *applyappsv1.Deplo
 	}
 
 	// ensure patches don't overwrite anything critical for operator function
+	//
+	// When migrations are skipped the deployment must not claim the real
+	// migration hash: check_migrations treats a deployment carrying the target
+	// hash as proof migrations already ran, so stamping the real hash here
+	// (overriding unpatchedDeployment's "skipped") causes a later
+	// migrations-required reconcile to skip the migration job entirely.
+	migrationAnnotation := migrationHash
+	if c.SkipMigrations {
+		migrationAnnotation = "skipped"
+	}
 	d.WithName(name).WithNamespace(c.Namespace).WithOwnerReferences(c.ownerRef()).
 		WithLabels(metadata.LabelsForComponent(c.Name, metadata.ComponentSpiceDBLabelValue)).
 		WithAnnotations(map[string]string{
-			metadata.SpiceDBMigrationRequirementsKey: migrationHash,
+			metadata.SpiceDBMigrationRequirementsKey: migrationAnnotation,
 		})
 	d.Spec.Selector.WithMatchLabels(map[string]string{metadata.KubernetesInstanceLabelKey: name})
 	d.Spec.Template.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2655,6 +2655,30 @@ func TestDeployment(t *testing.T) {
 		wantDeployment *applyappsv1.DeploymentApplyConfiguration
 	}{
 		{
+			name: "migration hash is preserved when migrations are not skipped",
+			cluster: v1alpha1.ClusterSpec{
+				SecretRef: "test-secret",
+				Config: json.RawMessage(`
+					{
+						"logLevel": "debug",
+						"datastoreEngine": "cockroachdb"
+					}
+				`),
+			},
+			secret: &corev1.Secret{Data: map[string][]byte{
+				"datastore_uri": []byte("uri"),
+				"preshared_key": []byte("psk"),
+			}},
+			wantDeployment: expectedDeployment(func(dep *applyappsv1.DeploymentApplyConfiguration) {
+				// migrations not skipped: the deployment must carry the real
+				// migration hash so check_migrations can tell it apart from a
+				// "skipped" deployment.
+				dep.WithAnnotations(map[string]string{
+					metadata.SpiceDBMigrationRequirementsKey: "1",
+				})
+			}),
+		},
+		{
 			name: "container name back compat: smp patch with old name",
 			cluster: v1alpha1.ClusterSpec{
 				SecretRef: "test-secret",
@@ -3734,7 +3758,10 @@ func expectedDeployment(apply ...func(dep *applyappsv1.DeploymentApplyConfigurat
 			metadata.KubernetesVersionLabelKey:   "v1",
 		}).
 		WithAnnotations(map[string]string{
-			metadata.SpiceDBMigrationRequirementsKey: "1",
+			// every TestDeployment case below sets skipMigrations: true, so the
+			// deployment must advertise "skipped" rather than the real migration
+			// hash (otherwise check_migrations would treat it as already migrated).
+			metadata.SpiceDBMigrationRequirementsKey: "skipped",
 		}).
 		WithOwnerReferences(applymetav1.OwnerReference().
 			WithName("test").


### PR DESCRIPTION
We ran into this debugging a stuck upgrade. When `skipMigrations` is set,
`unpatchedDeployment` sets the migration annotation to `"skipped"`, but then
`Deployment()` overwrites it back to the real hash in the "don't let patches
clobber critical stuff" block.

The problem is `check_migrations` uses that annotation to decide if migrations
already ran (job only gets created when `!hasDeployment && !hasJob`). So a
deployment that went through the skip path looks like it's already migrated, and
on the next reconcile where migrations are actually required it skips the job and
rolls the new version anyway -> pods crashloop with `datastore is not migrated`
and the rollout just sits there until someone hand-edits the annotation.

Fix is just to respect `SkipMigrations` in `Deployment()` too so it stays
`"skipped"`.

Tests: the existing `TestDeployment` cases all use skipMigrations:true and were
asserting the real hash, so they fail before this and pass after. Added one
case for the non-skip path to make sure it still keeps the real hash.

Didn't touch the higher level controller that waits on conditions - that part is
doing the right thing. Probably worth a followup to make "migrations done" key
off the job actually succeeding instead of the deployment annotation, but kept
this one small.