### PR TITLE
fix: clear resourceVersion before apply-patching SpiceDBCluster

### DIFF
--- a/e2e/cluster_test.go
+++ b/e2e/cluster_test.go
@@ -405,6 +405,12 @@ var _ = Describe("SpiceDBClusters", func() {
 					}
 				})
 
+				AfterEach(func() {
+					// wait for the resources holding datastore connections to be
+					// GCd before the database is dropped in DeferCleanup
+					AssertDependentResourceCleanup(cluster.Name, "spicedb")
+				})
+
 				It("reports un-recovered pod errors on the status", func() {
 					var lastCluster *v1alpha1.SpiceDBCluster
 					var condition *metav1.Condition

--- a/e2e/cluster_test.go
+++ b/e2e/cluster_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/restmapper"
 
+	"github.com/authzed/controller-idioms/pause"
 	"github.com/authzed/controller-idioms/typed"
 
 	"github.com/authzed/spicedb-operator/e2e/databases"
@@ -223,6 +224,37 @@ var _ = Describe("SpiceDBClusters", func() {
 					return c.FindStatusCondition(v1alpha1.ConditionTypePreconditionsFailed) != nil
 				})
 			})
+		})
+	})
+
+	Describe("With a failing migration job", func() {
+		BeforeEach(func() {
+			config["datastoreEngine"] = "postgres"
+			// a datastore that can never be reached, so the migration job can
+			// never succeed
+			secret.StringData["datastore_uri"] = "postgresql://spicedb:testtesttesttest@localhost:1/spicedb?sslmode=disable"
+			// fail the job on the first attempt instead of waiting out the
+			// default backoff policy
+			cluster.Spec.Patches = []v1alpha1.Patch{{
+				Kind:  "Job",
+				Patch: json.RawMessage(`{"spec": {"activeDeadlineSeconds": 1, "backoffLimit": 0}}`),
+			}}
+		})
+
+		It("self-pauses the cluster", func() {
+			ctx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+			defer cancel()
+
+			var paused *metav1.Condition
+			var labelled bool
+			Watch(ctx, client, v1alpha1ClusterGVR, ktypes.NamespacedName{Name: cluster.Name, Namespace: testNamespace}, "0", func(c *v1alpha1.SpiceDBCluster) bool {
+				logr.FromContextOrDiscard(ctx).Info("watch event", "labels", c.Labels, "status", c.Status)
+				paused = c.FindStatusCondition(pause.ConditionTypePaused)
+				_, labelled = c.Labels[metadata.PausedControllerSelectorKey]
+				return paused == nil || !labelled
+			})
+			Expect(labelled).To(BeTrue(), "expected the %s label on the cluster", metadata.PausedControllerSelectorKey)
+			Expect(paused).ToNot(BeNil(), "expected the Paused condition on the status")
 		})
 	})
 

--- a/pkg/controller/client.go
+++ b/pkg/controller/client.go
@@ -25,6 +25,10 @@ func (c *Controller) PatchStatus(ctx context.Context, patch *v1alpha1.SpiceDBClu
 }
 
 func (c *Controller) Patch(ctx context.Context, patch *v1alpha1.SpiceDBCluster) error {
+	// an apply patch that carries a resourceVersion is rejected with a conflict
+	// if the object has changed at all - e.g. by a status patch earlier in the
+	// same reconcile (as in self-pause), which would make this patch always fail
+	patch.ResourceVersion = ""
 	data, err := json.Marshal(patch)
 	if err != nil {
 		return err

--- a/pkg/controller/client_test.go
+++ b/pkg/controller/client_test.go
@@ -1,0 +1,46 @@
+package controller
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/authzed/spicedb-operator/pkg/apis/authzed/v1alpha1"
+)
+
+// A resourceVersion in an apply patch acts as an optimistic-lock
+// precondition, so a patch that carries one is rejected whenever the object
+// changed since it was read - e.g. by a status patch earlier in the same
+// reconcile, as in self-pause.
+func TestPatchOmitsResourceVersion(t *testing.T) {
+	dclient := fake.NewSimpleDynamicClient(scheme.Scheme)
+	var payload []byte
+	dclient.PrependReactor("patch", "spicedbclusters", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		payload = action.(k8stesting.PatchAction).GetPatch()
+		return true, &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": v1alpha1.SchemeGroupVersion.String(),
+			"kind":       v1alpha1.SpiceDBClusterKind,
+		}}, nil
+	})
+	c := &Controller{client: dclient}
+
+	cluster := &v1alpha1.SpiceDBCluster{ObjectMeta: metav1.ObjectMeta{
+		Name:            "test",
+		Namespace:       "test",
+		ResourceVersion: "42",
+	}}
+	require.NoError(t, c.Patch(t.Context(), cluster))
+
+	var patch struct {
+		Metadata map[string]any `json:"metadata"`
+	}
+	require.NoError(t, json.Unmarshal(payload, &patch))
+	require.NotContains(t, patch.Metadata, "resourceVersion")
+}


### PR DESCRIPTION
- **Fix a self-pause hot loop.** When a migration job fails, the operator pauses the cluster in two steps: a status patch adding the `Paused` condition, then a metadata patch adding the `authzed.com/controller-paused` label — both from the same in-memory object. The status patch bumps the object's resourceVersion, so the label patch always carried a stale resourceVersion, which server-side apply treats as an optimistic-lock precondition and rejects with a 409 — every time. The label never landed, so each reconcile interpreted the labelless `Paused` condition as a manual unpause and started over: a hot loop of ~360 conflicts/minute with the status flickering every second. Fixed by clearing `resourceVersion` before apply-patching, the same way `managedFields` is already cleared. Covered by a unit test on the patch payload and an e2e test that fails on `main` and passes with the fix.

- **Fix a flaky e2e teardown.** The postgres pod-error spec deleted the SpiceDBCluster asynchronously and then immediately dropped the logical database, while spicedb pods still held connections — failing cleanup with `ERROR: database is being accessed by other users (SQLSTATE 55006)`. The spec now waits for dependent resources to be GC'd before the drop, like the other specs do.