### PR TITLE
fix: report rollout status against the Deployment's own spec.replicas

### DIFF
--- a/pkg/controller/ensure_deployment.go
+++ b/pkg/controller/ensure_deployment.go
@@ -140,16 +140,18 @@ func (m *DeploymentHandler) Handle(ctx context.Context) {
 		}
 	}
 
-	// wait for deployment to be available
-	if cachedDeployment.Status.AvailableReplicas != config.Replicas ||
-		cachedDeployment.Status.ReadyReplicas != config.Replicas ||
-		cachedDeployment.Status.UpdatedReplicas != config.Replicas ||
-		cachedDeployment.Status.ObservedGeneration != cachedDeployment.Generation {
+	// wait for deployment to be available. Measure against the Deployment's own
+	// spec.replicas rather than config.replicas: when replicas are managed
+	// externally (an autoscaler scaling the Deployment after a spec.patches
+	// entry removes /spec/replicas) the operator no longer sets the field, and
+	// comparing to config.replicas would report a rollout that never completes.
+	desiredReplicas := desiredDeploymentReplicas(cachedDeployment, config.Replicas)
+	if !deploymentRolloutComplete(cachedDeployment, desiredReplicas) {
 		currentStatus.SetStatusCondition(v1alpha1.NewRollingCondition(
 			fmt.Sprintf("Waiting for deployment to be available: %d/%d available, %d/%d ready, %d/%d updated, %d/%d generation.",
-				cachedDeployment.Status.AvailableReplicas, config.Replicas,
-				cachedDeployment.Status.ReadyReplicas, config.Replicas,
-				cachedDeployment.Status.UpdatedReplicas, config.Replicas,
+				cachedDeployment.Status.AvailableReplicas, desiredReplicas,
+				cachedDeployment.Status.ReadyReplicas, desiredReplicas,
+				cachedDeployment.Status.UpdatedReplicas, desiredReplicas,
 				cachedDeployment.Status.ObservedGeneration, cachedDeployment.Generation,
 			)))
 		if err := m.patchStatus(ctx, currentStatus); err != nil {
@@ -172,4 +174,30 @@ func (m *DeploymentHandler) Handle(ctx context.Context) {
 	}
 
 	m.next.Handle(ctx)
+}
+
+// desiredDeploymentReplicas returns the replica count dep is being driven to.
+// It is the live Deployment's spec.replicas when set: the operator omits that
+// field from its server-side apply when replicas are managed externally (for
+// example an autoscaler scaling the Deployment after a spec.patches entry
+// removes /spec/replicas), so the live value, rather than the operator's
+// configured count, is what a rollout must be measured against. Falls back to
+// configured when the live field is unset.
+func desiredDeploymentReplicas(dep *appsv1.Deployment, configured int32) int32 {
+	if dep.Spec.Replicas != nil {
+		return *dep.Spec.Replicas
+	}
+	return configured
+}
+
+// deploymentRolloutComplete reports whether dep has finished rolling out to
+// desired replicas, using the same signals as `kubectl rollout status`: the
+// latest generation has been observed, every desired replica has been updated
+// to the current pod template and is available, and no replicas from a
+// previous revision remain.
+func deploymentRolloutComplete(dep *appsv1.Deployment, desired int32) bool {
+	return dep.Status.ObservedGeneration == dep.Generation &&
+		dep.Status.UpdatedReplicas == desired &&
+		dep.Status.Replicas == dep.Status.UpdatedReplicas &&
+		dep.Status.AvailableReplicas == dep.Status.UpdatedReplicas
 }

--- a/pkg/controller/ensure_deployment_test.go
+++ b/pkg/controller/ensure_deployment_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	applyappsv1 "k8s.io/client-go/applyconfigurations/apps/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/authzed/controller-idioms/handler"
 	"github.com/authzed/controller-idioms/queue/fake"
@@ -413,6 +414,43 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 				Conditions: []metav1.Condition{},
 			}},
 		},
+		{
+			// config.replicas is 2, but an autoscaler has scaled the Deployment
+			// to 6 after spec.replicas was patched out of the operator's apply.
+			// The rollout is judged against the live spec.replicas, so a fully
+			// available Deployment at 6 clears the condition instead of waiting
+			// forever for it to reach config.replicas.
+			name: "removes rollout status when replicas are externally managed",
+			currentStatus: &v1alpha1.SpiceDBCluster{Status: v1alpha1.ClusterStatus{
+				Conditions: []metav1.Condition{{
+					Type:               v1alpha1.ConditionTypeRolling,
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: now,
+					Reason:             "WaitingForDeploymentAvailability",
+					Message:            "Waiting for deployment to be available: 6/2 available, 6/2 ready, 6/2 updated, 0/0 generation.",
+				}},
+			}},
+			existingDeployments: []*appsv1.Deployment{{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+					metadata.SpiceDBConfigKey: "7ddaf0d5f794806f",
+				}},
+				Spec: appsv1.DeploymentSpec{Replicas: ptr.To[int32](6)},
+				Status: appsv1.DeploymentStatus{
+					Replicas:          6,
+					UpdatedReplicas:   6,
+					AvailableReplicas: 6,
+					ReadyReplicas:     6,
+				},
+			}},
+			replicas:          2,
+			migrationHash:     "testtesttesttest",
+			secretHash:        "secret",
+			expectPatchStatus: true,
+			expectNext:        nextKey,
+			expectStatus: &v1alpha1.SpiceDBCluster{Status: v1alpha1.ClusterStatus{
+				Conditions: []metav1.Condition{},
+			}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -481,6 +519,58 @@ func TestEnsureDeploymentHandler(t *testing.T) {
 				require.Equal(t, tt.expectRequeueAPIErr, ctrls.RequeueAPIErrArgsForCall(0))
 			}
 			require.Equal(t, tt.expectRequeueAfter, ctrls.RequeueAfterCallCount() == 1)
+		})
+	}
+}
+
+func TestDesiredDeploymentReplicas(t *testing.T) {
+	tests := []struct {
+		name       string
+		specValue  *int32
+		configured int32
+		expected   int32
+	}{
+		{name: "uses live spec.replicas when set", specValue: ptr.To[int32](6), configured: 2, expected: 6},
+		{name: "falls back to configured when spec.replicas is unset", specValue: nil, configured: 2, expected: 2},
+		{name: "uses live spec.replicas even when zero", specValue: ptr.To[int32](0), configured: 2, expected: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dep := &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Replicas: tt.specValue}}
+			require.Equal(t, tt.expected, desiredDeploymentReplicas(dep, tt.configured))
+		})
+	}
+}
+
+func TestDeploymentRolloutComplete(t *testing.T) {
+	deployment := func(generation, observed int64, replicas, updated, available int32) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Generation: generation},
+			Status: appsv1.DeploymentStatus{
+				ObservedGeneration: observed,
+				Replicas:           replicas,
+				UpdatedReplicas:    updated,
+				AvailableReplicas:  available,
+			},
+		}
+	}
+	tests := []struct {
+		name     string
+		dep      *appsv1.Deployment
+		desired  int32
+		expected bool
+	}{
+		{name: "complete when all replicas updated and available", dep: deployment(1, 1, 3, 3, 3), desired: 3, expected: true},
+		{name: "incomplete while spec generation not yet observed", dep: deployment(2, 1, 3, 3, 3), desired: 3, expected: false},
+		{name: "incomplete while replicas are still updating", dep: deployment(1, 1, 3, 2, 2), desired: 3, expected: false},
+		{name: "incomplete while old replicas remain", dep: deployment(1, 1, 4, 3, 3), desired: 3, expected: false},
+		{name: "incomplete while updated replicas are not yet available", dep: deployment(1, 1, 3, 3, 2), desired: 3, expected: false},
+		{name: "complete against an externally scaled count above config", dep: deployment(1, 1, 6, 6, 6), desired: 6, expected: true},
+		{name: "complete when scaled to zero", dep: deployment(1, 1, 0, 0, 0), desired: 0, expected: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, deploymentRolloutComplete(tt.dep, tt.desired))
 		})
 	}
 }


### PR DESCRIPTION
## Problem

The operator reports a perpetual `RollingDeployment` condition when a `SpiceDBCluster`'s Deployment has its replica count managed by something other than the operator.

`DeploymentHandler` gates rollout completion on the Deployment's `Available`/`Ready`/`UpdatedReplicas` all equalling `config.replicas`. That holds while the operator owns `spec.replicas`, but the operator's own `spec.patches` feature lets a user remove `/spec/replicas` from the applied Deployment so an external autoscaler (HPA/KEDA) can own the count. Once that happens the operator no longer sets `spec.replicas`, the live count no longer tracks `config.replicas`, and the condition never clears — the cluster reports e.g. `6/8 available` indefinitely while the handler requeues every 2s. The same mismatch can occur transiently when `config.replicas` is changed mid-rollout.

## Change

Measure rollout completion against the live Deployment's own `spec.replicas` rather than `config.replicas`, falling back to `config.replicas` only when the live field is unset. Completion now uses the same signals as `kubectl rollout status`: the latest generation has been observed, every desired replica has been updated to the current pod template and is available, and no replicas from a previous revision remain. The waiting-message denominators report the live desired count.

The logic lives in two small package-private helpers, `desiredDeploymentReplicas` and `deploymentRolloutComplete`. No API or CRD change.

## Tests

Added focused unit tests for both helpers and a `TestEnsureDeploymentHandler` case covering a fully-available Deployment whose external replica count differs from `config.replicas` (previously stuck rolling, now clears). `go test -race ./...` passes and `go mod tidy` is clean; e2e was not run locally.

Fixes #108
