### PR TITLE
chore: diagnose high memory usage

### DIFF
--- a/cmd/memprofile/main.go
+++ b/cmd/memprofile/main.go
@@ -1,0 +1,421 @@
+// Command memprofile attributes the spicedb-operator's startup memory to the
+// phases of its startup path, so that OOMKills at a given container limit can
+// be traced to a specific allocation rather than guessed at.
+//
+// It deliberately does not start the operator. Instead it walks the same
+// sequence pkg/cmd/run.Options.Run walks, taking a memory snapshot between each
+// step, so that each step's retained heap is reported separately:
+//
+//	baseline    process start: runtime, scheme registration, client construction
+//	discovery   REST config + discovery/dynamic/typed clients
+//	controller  controller.NewController() -- informers, handler chain, caches
+//	openapi     Factory.OpenAPISchema() -- parses the cluster's OpenAPI v2 spec
+//
+// The operator defers the openapi phase until a SpiceDBCluster actually uses a
+// strategic merge patch, so --stage=controller (the default) reflects a normal
+// startup and --stage=openapi measures the cost that deferral avoids. Use
+// --stage=all to see both.
+//
+// The number to compare against the container's memory limit is Max RSS, which
+// is the kernel high-water mark the OOM killer actually acts on. HeapAlloc
+// after a forced GC is the *retained* cost of a phase; TotalAlloc delta is the
+// churn through it (which drives GC pressure and the transient peak).
+//
+// Usage:
+//
+//	go run ./cmd/memprofile                      # normal startup path
+//	go run ./cmd/memprofile --stage=openapi      # the deferred schema cost
+//	go run ./cmd/memprofile --stage=all          # both, controller first
+//	go run ./cmd/memprofile --profile-dir=/tmp/p # write per-phase heap profiles
+//
+// Then, to see what is holding the retained bytes:
+//
+//	go tool pprof -http=: /tmp/p/openapi.heap
+package main
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"runtime/pprof"
+	"slices"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	"github.com/authzed/controller-idioms/typed"
+
+	"github.com/authzed/spicedb-operator/pkg/cmd/run"
+	"github.com/authzed/spicedb-operator/pkg/controller"
+)
+
+// Every stage builds on `discovery`, since the clients are needed throughout.
+// `controller` is the operator's real startup path and deliberately does NOT
+// resolve the OpenAPI schema, because the operator defers that until a cluster
+// actually uses a strategic merge patch. `openapi` forces that resolution so
+// the deferred cost can still be measured; `all` reports both, in that order,
+// so the controller path's RSS is read before the openapi probe inflates it.
+const (
+	stageDiscovery  = "discovery"
+	stageOpenAPI    = "openapi"
+	stageController = "controller"
+	stageAll        = "all"
+)
+
+var stageOrder = []string{stageDiscovery, stageOpenAPI, stageController, stageAll}
+
+type options struct {
+	stage            string
+	profileDir       string
+	cacheSyncWait    time.Duration
+	probeWireSize    bool
+	reportAPISurface bool
+}
+
+func main() {
+	o := &options{}
+	runOpts := run.RecommendedOptions()
+
+	cmd := &cobra.Command{
+		Use:          "memprofile [flags]",
+		Short:        "attribute spicedb-operator startup memory to startup phases",
+		SilenceUsage: true,
+		Long: strings.TrimSpace(`
+Measures where the operator's startup memory goes, phase by phase, against the
+cluster in the active kubecontext. Reports Max RSS (what the OOM killer sees),
+retained heap per phase, and allocation churn per phase.`),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return o.run(cmd.Context(), runOpts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&o.stage, "stage", stageController,
+		fmt.Sprintf("which startup phases to measure, one of %s", strings.Join(stageOrder, "|")))
+	flags.StringVar(&o.profileDir, "profile-dir", "",
+		"if set, write a heap profile per phase into this directory for `go tool pprof`")
+	flags.DurationVar(&o.cacheSyncWait, "cache-sync-timeout", 90*time.Second,
+		"how long the controller phase waits for informer caches to sync before giving up")
+	flags.BoolVar(&o.probeWireSize, "wire", false,
+		"additionally download the raw OpenAPI v2 document to report its wire size; this inflates Max RSS, so do not combine it with a run whose RSS number you intend to trust")
+	flags.BoolVar(&o.reportAPISurface, "api-surface", true,
+		"report the cluster's API surface (group/resource/CRD counts), which is what the openapi phase's cost scales with")
+
+	// Reuse the operator's own kubeconfig flags so that --kubeconfig, --context
+	// and friends behave identically to `spicedb-operator run`.
+	runOpts.ConfigFlags.AddFlags(flags)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func (o *options) run(ctx context.Context, runOpts *run.Options) error {
+	stageIdx := indexOf(stageOrder, o.stage)
+	if stageIdx < 0 {
+		return fmt.Errorf("unknown --stage %q, want one of %s", o.stage, strings.Join(stageOrder, "|"))
+	}
+	if o.profileDir != "" {
+		if err := os.MkdirAll(o.profileDir, 0o755); err != nil {
+			return err
+		}
+	}
+
+	// The operator sets no GOMEMLIMIT, so report what the runtime believes its
+	// ceiling is. A ceiling of ~9.2EB means "unset", i.e. the runtime will size
+	// the heap at GOGC% above live heap with no regard for the cgroup limit.
+	fmt.Printf("go %s  GOMAXPROCS=%d  GOGC=%d  GOMEMLIMIT=%s\n\n",
+		runtime.Version(), runtime.GOMAXPROCS(0), currentGOGC(), formatMemLimit(debug.SetMemoryLimit(-1)))
+
+	r := &reporter{profileDir: o.profileDir}
+	r.snap("baseline")
+
+	// --- discovery: REST config and the clients run.Options.Run builds ---
+	f := cmdutil.NewFactory(runOpts.ConfigFlags)
+	restConfig, err := f.ToRESTConfig()
+	if err != nil {
+		return fmt.Errorf("building REST config (is a kubecontext active?): %w", err)
+	}
+	run.DisableClientRateLimits(restConfig)
+
+	dclient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+	kclient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("cluster: %s\n", restConfig.Host)
+	r.snap(stageDiscovery)
+
+	var apiSurface string
+	if o.reportAPISurface {
+		apiSurface, err = describeAPISurface(discoveryClient)
+		if err != nil {
+			// A partial discovery failure is normal on clusters with a broken
+			// aggregated APIService; it should not abort the measurement.
+			apiSurface = fmt.Sprintf("(partial: %v)", err)
+		}
+	}
+
+	if o.stage == stageDiscovery {
+		r.report(apiSurface)
+		return nil
+	}
+
+	// --- controller: the operator's real startup path ---
+	// The factory is handed over as the lazy openapi.OpenAPIResourcesGetter,
+	// exactly as pkg/cmd/run does, so nothing here resolves the schema.
+	if o.stage == stageController || o.stage == stageAll {
+		syncCtx, cancel := context.WithTimeout(ctx, o.cacheSyncWait)
+		defer cancel()
+
+		ctrl, err := controller.NewController(
+			syncCtx,
+			typed.NewRegistry(),
+			dclient,
+			kclient,
+			f,
+			"", // no operator config file; the update graph is measured separately
+			"",
+			record.NewBroadcaster(),
+			nil, // all namespaces, matching the operator's default
+		)
+		if err != nil {
+			return fmt.Errorf("building controller: %w", err)
+		}
+		if syncCtx.Err() != nil {
+			fmt.Fprintf(os.Stderr,
+				"warning: informer caches did not sync within %s; the controller phase is understated\n", o.cacheSyncWait)
+		}
+		r.retain(ctrl)
+		r.snap(stageController)
+	}
+
+	// --- openapi: the cost the operator now defers ---
+	if o.stage == stageOpenAPI || o.stage == stageAll {
+		if o.probeWireSize {
+			size, err := probeOpenAPIWireSize(ctx, restConfig)
+			if err != nil {
+				return fmt.Errorf("probing OpenAPI v2 wire size: %w", err)
+			}
+			fmt.Printf("openapi v2 wire size (protobuf, as discovery fetches it): %s\n", humanBytes(size))
+		}
+
+		resources, err := f.OpenAPISchema()
+		if err != nil {
+			return fmt.Errorf("fetching OpenAPI schema: %w", err)
+		}
+		// Keep the result reachable so the snapshot measures what a cluster
+		// using strategic merge patches would retain, not garbage.
+		r.retain(resources)
+		r.snap(stageOpenAPI)
+	}
+
+	r.report(apiSurface)
+	return nil
+}
+
+// reporter accumulates per-phase memory snapshots and keeps every measured
+// object alive until the final report, so that retained heap is not optimized
+// or collected away mid-run.
+type reporter struct {
+	profileDir string
+	snaps      []snapshot
+	retained   []any
+}
+
+type snapshot struct {
+	label      string
+	heapAlloc  uint64
+	heapSys    uint64
+	sys        uint64
+	totalAlloc uint64
+	maxRSS     uint64
+}
+
+func (r *reporter) retain(v any) { r.retained = append(r.retained, v) }
+
+func (r *reporter) snap(label string) {
+	// Two collections: the first frees unreachable objects, the second reclaims
+	// anything whose finalizer the first pass queued, so HeapAlloc settles on
+	// genuinely-retained bytes.
+	runtime.GC()
+	runtime.GC()
+
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
+	var ru syscall.Rusage
+	_ = syscall.Getrusage(syscall.RUSAGE_SELF, &ru)
+
+	r.snaps = append(r.snaps, snapshot{
+		label:      label,
+		heapAlloc:  ms.HeapAlloc,
+		heapSys:    ms.HeapSys,
+		sys:        ms.Sys,
+		totalAlloc: ms.TotalAlloc,
+		maxRSS:     maxRSSBytes(ru),
+	})
+
+	if r.profileDir != "" {
+		path := filepath.Join(r.profileDir, label+".heap")
+		f, err := os.Create(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not write heap profile %s: %v\n", path, err)
+			return
+		}
+		defer f.Close()
+		if err := pprof.WriteHeapProfile(f); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not write heap profile %s: %v\n", path, err)
+		}
+	}
+}
+
+func (r *reporter) report(apiSurface string) {
+	if apiSurface != "" {
+		fmt.Printf("\napi surface: %s\n", apiSurface)
+	}
+
+	fmt.Printf("\n%-12s %12s %12s %12s %12s\n",
+		"phase", "retained", "+retained", "churn", "max rss")
+	fmt.Println(strings.Repeat("-", 64))
+	for i, s := range r.snaps {
+		var retainedDelta, churn string
+		if i == 0 {
+			retainedDelta, churn = "-", "-"
+		} else {
+			prev := r.snaps[i-1]
+			retainedDelta = "+" + humanBytes(saturatingSub(s.heapAlloc, prev.heapAlloc))
+			churn = humanBytes(saturatingSub(s.totalAlloc, prev.totalAlloc))
+		}
+		fmt.Printf("%-12s %12s %12s %12s %12s\n",
+			s.label, humanBytes(s.heapAlloc), retainedDelta, churn, humanBytes(s.maxRSS))
+	}
+
+	last := r.snaps[len(r.snaps)-1]
+	fmt.Printf("\nretained live heap: %s\n", humanBytes(last.heapAlloc))
+	fmt.Printf("heap reserved from OS (HeapSys): %s\n", humanBytes(last.heapSys))
+	fmt.Printf("total runtime footprint (Sys): %s\n", humanBytes(last.sys))
+	fmt.Printf("MAX RSS (compare this to the container limit): %s\n", humanBytes(last.maxRSS))
+
+	// Keep everything alive past the final read.
+	runtime.KeepAlive(r.retained)
+}
+
+// probeOpenAPIWireSize fetches the OpenAPI v2 document with the same content
+// negotiation client-go's discovery client uses, and reports its size on the
+// wire. The bytes are dropped before returning, but Max RSS keeps the high-water
+// mark, which is why this is opt-in.
+func probeOpenAPIWireSize(ctx context.Context, restConfig *rest.Config) (uint64, error) {
+	// Borrow the discovery client's REST client, which is already configured
+	// with the serializer and content type negotiation this path needs.
+	d, err := discovery.NewDiscoveryClientForConfig(rest.CopyConfig(restConfig))
+	if err != nil {
+		return 0, err
+	}
+	raw, err := d.RESTClient().Get().
+		AbsPath("/openapi/v2").
+		SetHeader("Accept", "application/com.github.proto-openapi.spec.v2@v1.0+protobuf").
+		Do(ctx).
+		Raw()
+	if err != nil {
+		return 0, err
+	}
+	return uint64(len(raw)), nil
+}
+
+// describeAPISurface counts what the OpenAPI document has to describe. The
+// openapi phase's cost scales with these numbers, not with the number of
+// SpiceDBClusters, which is why a small deployment can still OOM.
+func describeAPISurface(d discovery.DiscoveryInterface) (string, error) {
+	lists, err := d.ServerPreferredResources()
+	// ServerPreferredResources returns partial results alongside an error when
+	// some group is unreachable; count whatever came back either way.
+	groups := map[string]struct{}{}
+	resourceCount := 0
+	for _, l := range lists {
+		if l == nil {
+			continue
+		}
+		groups[l.GroupVersion] = struct{}{}
+		resourceCount += len(l.APIResources)
+	}
+	summary := fmt.Sprintf("%d group-versions, %d resources", len(groups), resourceCount)
+	if err != nil {
+		return summary, err
+	}
+	return summary, nil
+}
+
+func currentGOGC() int {
+	// SetGCPercent returns the previous value; set it straight back.
+	prev := debug.SetGCPercent(100)
+	debug.SetGCPercent(prev)
+	return prev
+}
+
+func formatMemLimit(limit int64) string {
+	// math.MaxInt64 is the runtime's "no limit" sentinel. A negative limit is
+	// not reachable via SetMemoryLimit, but guard the conversion regardless.
+	if limit == math.MaxInt64 || limit < 0 {
+		return "unset (no ceiling; heap grows to GOGC% above live heap)"
+	}
+	return humanBytes(uint64(limit))
+}
+
+func maxRSSBytes(ru syscall.Rusage) uint64 {
+	if ru.Maxrss < 0 {
+		return 0
+	}
+	if runtime.GOOS == "darwin" {
+		return uint64(ru.Maxrss)
+	}
+	return uint64(ru.Maxrss) * 1024 // linux reports kilobytes
+}
+
+func saturatingSub(a, b uint64) uint64 {
+	if a < b {
+		return 0
+	}
+	return a - b
+}
+
+func humanBytes(b uint64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	suffixes := []string{"KiB", "MiB", "GiB", "TiB"}
+	val := float64(b)
+	i := -1
+	for val >= unit && i < len(suffixes)-1 {
+		val /= unit
+		i++
+	}
+	return fmt.Sprintf("%.1f %s", val, suffixes[i])
+}
+
+func indexOf(haystack []string, needle string) int {
+	return slices.Index(haystack, needle)
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/fatih/camelcase v1.0.0
 	github.com/go-logr/logr v1.4.3
+	github.com/google/gnostic-models v0.7.0
 	github.com/gosimple/slug v1.15.0
 	github.com/jzelinskie/stringz v0.0.3
 	github.com/magefile/mage v1.15.0
@@ -24,6 +25,7 @@ require (
 	k8s.io/component-base v0.36.0-alpha.0
 	k8s.io/controller-manager v0.36.0-alpha.0
 	k8s.io/klog/v2 v2.130.1
+	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912
 	k8s.io/kubectl v0.36.0-alpha.0
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 	sigs.k8s.io/kind v0.31.0
@@ -63,7 +65,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.26.0 // indirect
-	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260709232956-b9395ee17fa0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -138,7 +139,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.34.0-alpha.2 // indirect
 	k8s.io/code-generator v0.34.0-alpha.2 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250604051438-85fd79dbfd9f // indirect
-	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	mvdan.cc/gofumpt v0.7.0 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
 	sigs.k8s.io/controller-tools v0.17.2 // indirect

--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -132,11 +132,6 @@ func (o *Options) Run(ctx context.Context, f cmdutil.Factory) error {
 		}
 	}
 
-	resources, err := f.OpenAPISchema()
-	if err != nil {
-		return err
-	}
-
 	registry := typed.NewRegistry()
 	eventSink := &typedcorev1.EventSinkImpl{Interface: kclient.CoreV1().Events("")}
 	broadcaster := record.NewBroadcaster()
@@ -155,7 +150,11 @@ func (o *Options) Run(ctx context.Context, f cmdutil.Factory) error {
 		controllers = append(controllers, staticSpiceDBController)
 	}
 
-	ctrl, err := controller.NewController(ctx, registry, dclient, kclient, resources, o.OperatorConfigPath, o.BaseImage, broadcaster, o.WatchNamespaces)
+	// The factory is passed rather than the resolved schema: it satisfies
+	// openapi.OpenAPIResourcesGetter and memoizes, so the cluster's OpenAPI v2
+	// document (~100MiB of retained heap) is only fetched and parsed if a
+	// SpiceDBCluster actually uses a strategic merge patch.
+	ctrl, err := controller.NewController(ctx, registry, dclient, kclient, f, o.OperatorConfigPath, o.BaseImage, broadcaster, o.WatchNamespaces)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/errors"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -28,6 +29,7 @@ import (
 	"github.com/authzed/controller-idioms/typed"
 
 	"github.com/authzed/spicedb-operator/pkg/apis/authzed/v1alpha1"
+	"github.com/authzed/spicedb-operator/pkg/config"
 	"github.com/authzed/spicedb-operator/pkg/controller"
 	"github.com/authzed/spicedb-operator/pkg/crds"
 )
@@ -150,11 +152,19 @@ func (o *Options) Run(ctx context.Context, f cmdutil.Factory) error {
 		controllers = append(controllers, staticSpiceDBController)
 	}
 
-	// The factory is passed rather than the resolved schema: it satisfies
-	// openapi.OpenAPIResourcesGetter and memoizes, so the cluster's OpenAPI v2
-	// document (~100MiB of retained heap) is only fetched and parsed if a
-	// SpiceDBCluster actually uses a strategic merge patch.
-	ctrl, err := controller.NewController(ctx, registry, dclient, kclient, f, o.OperatorConfigPath, o.BaseImage, broadcaster, o.WatchNamespaces)
+	// A getter is passed rather than a resolved schema so that the cluster's
+	// OpenAPI v2 document is only fetched and parsed if a SpiceDBCluster
+	// actually uses a strategic merge patch. The models-only getter is used in
+	// preference to the factory's (which also satisfies the interface) because
+	// it drops the raw document after parsing instead of retaining it; see
+	// config.ModelsOnlyResourcesGetter.
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+	resourcesGetter := config.NewModelsOnlyResourcesGetter(discoveryClient)
+
+	ctrl, err := controller.NewController(ctx, registry, dclient, kclient, resourcesGetter, o.OperatorConfigPath, o.BaseImage, broadcaster, o.WatchNamespaces)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -142,8 +142,9 @@ func (r RawConfig) Pop(key string) string {
 type Config struct {
 	MigrationConfig
 	SpiceConfig
-	Patches   []v1alpha1.Patch
-	Resources openapi.Resources
+	Patches []v1alpha1.Patch
+	// Resources loads the cluster's OpenAPI schema on demand; see ApplyPatches.
+	Resources openapi.OpenAPIResourcesGetter
 }
 
 // MigrationConfig stores data that is relevant for running migrations
@@ -201,7 +202,7 @@ type PDBConfig struct {
 }
 
 // NewConfig checks that the values in the config + the secrets are sane
-func NewConfig(cluster *v1alpha1.SpiceDBCluster, globalConfig *OperatorConfig, secrets map[string]*corev1.Secret, resources openapi.Resources) (*Config, Warning, error) {
+func NewConfig(cluster *v1alpha1.SpiceDBCluster, globalConfig *OperatorConfig, secrets map[string]*corev1.Secret, resources openapi.OpenAPIResourcesGetter) (*Config, Warning, error) {
 	if cluster.Spec.Config == nil {
 		return nil, nil, fmt.Errorf("couldn't parse empty config")
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -33,8 +33,10 @@ import (
 	"github.com/authzed/spicedb-operator/pkg/updates"
 )
 
-func newFakeResources() *openapitesting.FakeResources {
-	return openapitesting.NewFakeResources(filepath.Join("testdata", "swagger.1.26.3.json"))
+func newFakeResources() StaticResourcesGetter {
+	return StaticResourcesGetter{
+		Resources: openapitesting.NewFakeResources(filepath.Join("testdata", "swagger.1.26.3.json")),
+	}
 }
 
 // singleSecretMap wraps a single secret in a map using the given name key.

--- a/pkg/config/openapi.go
+++ b/pkg/config/openapi.go
@@ -1,0 +1,148 @@
+package config
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/kube-openapi/pkg/util/proto"
+	"k8s.io/kubectl/pkg/util/openapi"
+)
+
+// groupVersionKindExtensionKey is the OpenAPI extension that maps a model
+// definition to the GroupVersionKinds it describes.
+const groupVersionKindExtensionKey = "x-kubernetes-group-version-kind"
+
+// StaticResourcesGetter adapts an already-resolved openapi.Resources to the
+// lazy openapi.OpenAPIResourcesGetter interface, for callers that have the
+// schema in hand and don't need it loaded on demand.
+type StaticResourcesGetter struct {
+	Resources openapi.Resources
+}
+
+func (s StaticResourcesGetter) OpenAPISchema() (openapi.Resources, error) {
+	return s.Resources, nil
+}
+
+// ModelsOnlyResourcesGetter resolves the cluster's OpenAPI v2 schema on first
+// use and retains only the parts strategic merge patching needs.
+//
+// kubectl's own openapi.Resources implementation additionally retains the raw
+// gnostic *openapi_v2.Document for the lifetime of the process, solely so that
+// GetConsumes can walk its paths. That document is the majority of the schema's
+// memory cost -- on the order of 60MiB of protobuf struct graph for a cluster
+// with a couple hundred resources -- and this operator never calls GetConsumes.
+// Scoping the document to the parse lets the garbage collector reclaim it.
+type ModelsOnlyResourcesGetter struct {
+	client discovery.OpenAPISchemaInterface
+
+	once      sync.Once
+	resources openapi.Resources
+	err       error
+}
+
+var _ openapi.OpenAPIResourcesGetter = (*ModelsOnlyResourcesGetter)(nil)
+
+func NewModelsOnlyResourcesGetter(client discovery.OpenAPISchemaInterface) *ModelsOnlyResourcesGetter {
+	return &ModelsOnlyResourcesGetter{client: client}
+}
+
+// OpenAPISchema fetches and parses the schema on first call and memoizes the
+// result, including errors: a failure is not retried, matching the behavior of
+// kubectl's CachedOpenAPIParser.
+func (g *ModelsOnlyResourcesGetter) OpenAPISchema() (openapi.Resources, error) {
+	g.once.Do(func() {
+		// doc is scoped to this closure deliberately; nothing may retain it
+		// past the parse or the memory saving is lost.
+		doc, err := g.client.OpenAPISchema()
+		if err != nil {
+			g.err = fmt.Errorf("couldn't fetch OpenAPI schema: %w", err)
+			return
+		}
+		models, err := proto.NewOpenAPIData(doc)
+		if err != nil {
+			g.err = fmt.Errorf("couldn't parse OpenAPI schema: %w", err)
+			return
+		}
+		g.resources = newModelsOnlyResources(models)
+	})
+	return g.resources, g.err
+}
+
+// modelsOnlyResources implements openapi.Resources over parsed models alone.
+type modelsOnlyResources struct {
+	kindToModel map[schema.GroupVersionKind]string
+	models      proto.Models
+}
+
+var _ openapi.Resources = (*modelsOnlyResources)(nil)
+
+func newModelsOnlyResources(models proto.Models) *modelsOnlyResources {
+	kindToModel := make(map[schema.GroupVersionKind]string)
+	for _, name := range models.ListModels() {
+		model := models.LookupModel(name)
+		if model == nil {
+			continue
+		}
+		for _, gvk := range parseGroupVersionKind(model) {
+			if len(gvk.Kind) > 0 {
+				kindToModel[gvk] = name
+			}
+		}
+	}
+	return &modelsOnlyResources{kindToModel: kindToModel, models: models}
+}
+
+func (r *modelsOnlyResources) LookupResource(gvk schema.GroupVersionKind) proto.Schema {
+	name, ok := r.kindToModel[gvk]
+	if !ok {
+		return nil
+	}
+	return r.models.LookupModel(name)
+}
+
+// GetConsumes is part of openapi.Resources but cannot be answered without the
+// raw OpenAPI document, which is deliberately not retained. Nothing in this
+// operator calls it; strategic merge patching only needs LookupResource.
+func (r *modelsOnlyResources) GetConsumes(_ schema.GroupVersionKind, _ string) []string {
+	return nil
+}
+
+// parseGroupVersionKind reads the GroupVersionKinds a model describes from its
+// extensions. It mirrors the unexported equivalent in k8s.io/kubectl's openapi
+// package, including the map[interface{}]interface{} shape that kube-openapi's
+// vendor extension decoding produces, so that lookups resolve identically.
+func parseGroupVersionKind(s proto.Schema) []schema.GroupVersionKind {
+	gvkExtension, ok := s.GetExtensions()[groupVersionKindExtensionKey]
+	if !ok {
+		return nil
+	}
+
+	gvkList, ok := gvkExtension.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	result := make([]schema.GroupVersionKind, 0, len(gvkList))
+	for _, item := range gvkList {
+		gvkMap, ok := item.(map[interface{}]interface{})
+		if !ok {
+			continue
+		}
+		group, ok := gvkMap["group"].(string)
+		if !ok {
+			continue
+		}
+		version, ok := gvkMap["version"].(string)
+		if !ok {
+			continue
+		}
+		kind, ok := gvkMap["kind"].(string)
+		if !ok {
+			continue
+		}
+		result = append(result, schema.GroupVersionKind{Group: group, Version: version, Kind: kind})
+	}
+	return result
+}

--- a/pkg/config/openapi_test.go
+++ b/pkg/config/openapi_test.go
@@ -1,0 +1,181 @@
+package config
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	openapi_v2 "github.com/google/gnostic-models/openapiv2"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	applyappsv1 "k8s.io/client-go/applyconfigurations/apps/v1"
+	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	"k8s.io/kube-openapi/pkg/util/proto"
+	prototesting "k8s.io/kube-openapi/pkg/util/proto/testing"
+	"k8s.io/kubectl/pkg/util/openapi"
+	openapitesting "k8s.io/kubectl/pkg/util/openapi/testing"
+
+	"github.com/authzed/spicedb-operator/pkg/apis/authzed/v1alpha1"
+)
+
+// patchedGVKs are the kinds the operator applies patches to, which are the only
+// kinds LookupResource is ever called for.
+var patchedGVKs = []schema.GroupVersionKind{
+	{Group: "", Version: "v1", Kind: "ServiceAccount"},
+	{Group: "", Version: "v1", Kind: "Service"},
+	{Group: "apps", Version: "v1", Kind: "Deployment"},
+	{Group: "batch", Version: "v1", Kind: "Job"},
+	{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "Role"},
+	{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"},
+	{Group: "policy", Version: "v1", Kind: "PodDisruptionBudget"},
+}
+
+// TestModelsOnlyResourcesMatchesKubectl is the load-bearing test for dropping
+// the raw OpenAPI document: the models-only implementation must resolve every
+// kind the operator patches to exactly the same model kubectl's implementation
+// resolves it to. If these diverge, strategic merge patches would silently
+// change behavior (merge keys would be looked up against the wrong schema, or
+// not at all).
+func TestModelsOnlyResourcesMatchesKubectl(t *testing.T) {
+	for _, swagger := range []string{"swagger.1.26.3.json", "swagger.1.30.2.json"} {
+		t.Run(swagger, func(t *testing.T) {
+			path := filepath.Join("testdata", swagger)
+
+			doc, err := (&prototesting.Fake{Path: path}).OpenAPISchema()
+			require.NoError(t, err)
+			reference, err := openapi.NewOpenAPIData(doc)
+			require.NoError(t, err)
+
+			got, err := NewModelsOnlyResourcesGetter(&prototesting.Fake{Path: path}).OpenAPISchema()
+			require.NoError(t, err)
+
+			for _, gvk := range patchedGVKs {
+				t.Run(gvk.Kind, func(t *testing.T) {
+					want := reference.LookupResource(gvk)
+					actual := got.LookupResource(gvk)
+
+					// Fixtures are pinned to specific Kubernetes versions and
+					// don't all describe every kind at the group-version the
+					// operator uses today (1.26.3 has PodDisruptionBudget only
+					// at policy/v1beta1). What must hold is that the two
+					// implementations agree, present or not.
+					if want == nil {
+						require.Nil(t, actual, "models-only resolved %s that kubectl did not", gvk)
+						t.Skipf("fixture does not describe %s", gvk)
+					}
+					require.NotNil(t, actual, "models-only lookup lost %s", gvk)
+
+					// Compare the model's path and its sorted field names.
+					// proto.Kind.GetName() is deliberately not used: it renders
+					// an unsorted map iteration and is unstable between parses.
+					require.Equal(t, want.GetPath().String(), actual.GetPath().String())
+
+					wantKind, ok := want.(*proto.Kind)
+					require.True(t, ok, "expected %s to resolve to a Kind", gvk)
+					actualKind, ok := actual.(*proto.Kind)
+					require.True(t, ok, "expected %s to resolve to a Kind", gvk)
+					require.Equal(t, wantKind.Keys(), actualKind.Keys())
+				})
+			}
+		})
+	}
+}
+
+// TestModelsOnlyResourcesPatchesIdentically is the behavioral counterpart to
+// the lookup test. A strategic merge patch that targets one container by name
+// only merges (rather than replaces the whole list) if the schema supplies the
+// "name" merge key for spec.template.spec.containers. Applying the same patch
+// through kubectl's implementation and the models-only one must therefore
+// produce byte-identical output.
+func TestModelsOnlyResourcesPatchesIdentically(t *testing.T) {
+	path := filepath.Join("testdata", "swagger.1.30.2.json")
+
+	patches := []v1alpha1.Patch{{
+		Kind: "Deployment",
+		Patch: json.RawMessage(`
+spec:
+  template:
+    spec:
+      containers:
+      - name: spicedb
+        image: patched-image:v1`),
+	}}
+
+	deployment := func() *applyappsv1.DeploymentApplyConfiguration {
+		return applyappsv1.Deployment("test", "test").
+			WithSpec(applyappsv1.DeploymentSpec().
+				WithTemplate(applycorev1.PodTemplateSpec().
+					WithSpec(applycorev1.PodSpec().
+						WithContainers(
+							applycorev1.Container().WithName("spicedb").WithImage("original:v0"),
+							applycorev1.Container().WithName("sidecar").WithImage("sidecar:v0"),
+						))))
+	}
+
+	getters := map[string]openapi.OpenAPIResourcesGetter{
+		"kubectl": StaticResourcesGetter{Resources: openapitesting.NewFakeResources(path)},
+		"models-only": func() openapi.OpenAPIResourcesGetter {
+			return NewModelsOnlyResourcesGetter(&prototesting.Fake{Path: path})
+		}(),
+	}
+
+	results := make(map[string][]byte, len(getters))
+	for name, getter := range getters {
+		out := deployment()
+		count, patched, err := ApplyPatches(deployment(), out, patches, getter)
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+		require.True(t, patched)
+
+		encoded, err := json.Marshal(out)
+		require.NoError(t, err)
+		results[name] = encoded
+
+		// The merge key must have been honored: the sidecar survives and the
+		// targeted container is updated in place.
+		require.Contains(t, string(encoded), "patched-image:v1")
+		require.Contains(t, string(encoded), "sidecar:v0",
+			"sidecar was dropped, so the containers list was replaced instead of merged")
+	}
+
+	require.JSONEq(t, string(results["kubectl"]), string(results["models-only"]))
+}
+
+func TestModelsOnlyResourcesUnknownKind(t *testing.T) {
+	got, err := NewModelsOnlyResourcesGetter(&prototesting.Fake{
+		Path: filepath.Join("testdata", "swagger.1.30.2.json"),
+	}).OpenAPISchema()
+	require.NoError(t, err)
+
+	require.Nil(t, got.LookupResource(schema.GroupVersionKind{
+		Group: "authzed.com", Version: "v1alpha1", Kind: "NotAThing",
+	}))
+}
+
+// TestModelsOnlyResourcesGetterMemoizes guards the property the memory saving
+// depends on: the document is fetched and parsed once, no matter how many
+// patches are applied over the operator's lifetime.
+func TestModelsOnlyResourcesGetterMemoizes(t *testing.T) {
+	counter := &countingSchemaClient{
+		Fake: prototesting.Fake{Path: filepath.Join("testdata", "swagger.1.30.2.json")},
+	}
+	getter := NewModelsOnlyResourcesGetter(counter)
+
+	first, err := getter.OpenAPISchema()
+	require.NoError(t, err)
+	second, err := getter.OpenAPISchema()
+	require.NoError(t, err)
+
+	require.Same(t, first, second)
+	require.Equal(t, 1, counter.calls)
+}
+
+type countingSchemaClient struct {
+	prototesting.Fake
+	calls int
+}
+
+func (c *countingSchemaClient) OpenAPISchema() (*openapi_v2.Document, error) {
+	c.calls++
+	return c.Fake.OpenAPISchema()
+}

--- a/pkg/config/patch.go
+++ b/pkg/config/patch.go
@@ -18,17 +18,6 @@ import (
 
 const wildcard = "*"
 
-// StaticResourcesGetter adapts an already-resolved openapi.Resources to the
-// lazy openapi.OpenAPIResourcesGetter interface, for callers that have the
-// schema in hand and don't need it loaded on demand.
-type StaticResourcesGetter struct {
-	Resources openapi.Resources
-}
-
-func (s StaticResourcesGetter) OpenAPISchema() (openapi.Resources, error) {
-	return s.Resources, nil
-}
-
 // ApplyPatches applies a set of patches to an object.
 // It returns the number of patches applied, a bool indicating whether there
 // were matching patches and the input differed from the output, and any errors

--- a/pkg/config/patch.go
+++ b/pkg/config/patch.go
@@ -18,11 +18,27 @@ import (
 
 const wildcard = "*"
 
+// StaticResourcesGetter adapts an already-resolved openapi.Resources to the
+// lazy openapi.OpenAPIResourcesGetter interface, for callers that have the
+// schema in hand and don't need it loaded on demand.
+type StaticResourcesGetter struct {
+	Resources openapi.Resources
+}
+
+func (s StaticResourcesGetter) OpenAPISchema() (openapi.Resources, error) {
+	return s.Resources, nil
+}
+
 // ApplyPatches applies a set of patches to an object.
 // It returns the number of patches applied, a bool indicating whether there
 // were matching patches and the input differed from the output, and any errors
 // that occurred.
-func ApplyPatches[K any](object, out K, patches []v1alpha1.Patch, resources openapi.Resources) (int, bool, error) {
+//
+// resourcesGetter is only consulted for strategic merge patches, which need the
+// cluster's OpenAPI schema to determine merge keys. Resolving that schema costs
+// on the order of 100MiB of retained heap, so it is deliberately passed as a
+// getter and resolved on first use rather than eagerly at operator startup.
+func ApplyPatches[K any](object, out K, patches []v1alpha1.Patch, resourcesGetter openapi.OpenAPIResourcesGetter) (int, bool, error) {
 	// marshal object to json for patching
 	encoded, err := json.Marshal(object)
 	if err != nil {
@@ -72,6 +88,13 @@ func ApplyPatches[K any](object, out K, patches []v1alpha1.Patch, resources open
 				gv, err := schema.ParseGroupVersion(*typeMeta.APIVersion)
 				if err != nil {
 					errs = append(errs, fmt.Errorf("error applying patch %d, to object: %w", i, err))
+					continue
+				}
+				// Resolved here, at the only point that needs it. The getter
+				// memoizes, so this is a cheap call after the first.
+				resources, err := resourcesGetter.OpenAPISchema()
+				if err != nil {
+					errs = append(errs, fmt.Errorf("error applying patch %d, couldn't load OpenAPI schema: %w", i, err))
 					continue
 				}
 				gvkSchema := resources.LookupResource(gv.WithKind(*typeMeta.Kind))

--- a/pkg/config/patch_test.go
+++ b/pkg/config/patch_test.go
@@ -37,7 +37,9 @@ type patchTestCase[K any] struct {
 
 func runPatchTests[K any](t *testing.T, cases []patchTestCase[K]) {
 	// https://github.com/kubernetes/kubernetes/blob/v1.30.2/api/openapi-spec/swagger.json
-	resources := openapitesting.NewFakeResources(filepath.Join("testdata", "swagger.1.30.2.json"))
+	resources := StaticResourcesGetter{
+		Resources: openapitesting.NewFakeResources(filepath.Join("testdata", "swagger.1.30.2.json")),
+	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			count, patched, err := ApplyPatches(tt.object, tt.out, tt.patches, resources)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -99,7 +99,7 @@ type Controller struct {
 	namespaces  []string
 	client      dynamic.Interface
 	kclient     kubernetes.Interface
-	resources   openapi.Resources
+	resources   openapi.OpenAPIResourcesGetter
 	mainHandler handler.Handler
 
 	// config
@@ -109,7 +109,7 @@ type Controller struct {
 	lastConfigHash atomic.Uint64
 }
 
-func NewController(ctx context.Context, registry *typed.Registry, dclient dynamic.Interface, kclient kubernetes.Interface, resources openapi.Resources, configFilePath, baseImage string, broadcaster record.EventBroadcaster, namespaces []string) (*Controller, error) {
+func NewController(ctx context.Context, registry *typed.Registry, dclient dynamic.Interface, kclient kubernetes.Interface, resources openapi.OpenAPIResourcesGetter, configFilePath, baseImage string, broadcaster record.EventBroadcaster, namespaces []string) (*Controller, error) {
 	// If no namespaces are provided, watch all namespaces
 	if len(namespaces) == 0 {
 		namespaces = []string{metav1.NamespaceAll}

--- a/pkg/controller/validate_config.go
+++ b/pkg/controller/validate_config.go
@@ -20,7 +20,7 @@ const EventInvalidSpiceDBConfig = "InvalidSpiceDBConfig"
 
 type ValidateConfigHandler struct {
 	recorder    record.EventRecorder
-	resources   openapi.Resources
+	resources   openapi.OpenAPIResourcesGetter
 	patchStatus func(ctx context.Context, patch *v1alpha1.SpiceDBCluster) error
 	next        handler.ContextHandler
 }


### PR DESCRIPTION
## Description
We've observed spicedb-operator pods OOMthrashing with 250mb of limit, which feels excessive. This is an attempt to reduce that usage.

## Changes
* Add a memory diagnosis script
* Make OpenAPI schema request lazy + memoized

## Testing
Review. See that tests still pass.